### PR TITLE
User/lance/add config to astrokat cals

### DIFF
--- a/astrokat/observatory.py
+++ b/astrokat/observatory.py
@@ -1,4 +1,5 @@
 import os
+import json
 import ephem
 import numpy
 import katpoint

--- a/astrokat/observatory.py
+++ b/astrokat/observatory.py
@@ -1,3 +1,4 @@
+import os
 import ephem
 import numpy
 import katpoint
@@ -6,9 +7,29 @@ from datetime import datetime
 from simulate import user_logger, setobserver
 from utility import katpoint_target, lst2utc
 
+
 try:
     import katconf
-except ImportError:
+    # Set up configuration sourcei
+    config_path = '/var/kat/config'
+    node_file = '/var/kat/node.conf'
+    if os.path.isdir(config_path):
+        katconf.set_config(katconf.environ(override=config_path))
+    elif os.path.isfile(node_file):
+        with open(node_file, 'r') as fh:
+            node_conf = json.loads(fh.read())
+        for key, val in node_conf.items():
+            # Remove comments at the end of the line
+            val = val.split("#", 1)[0]
+            settings[key] = val.strip()
+            if node_conf.get("configuri", False):
+                katconf.set_config(katconf.environ(node_conf["configuri"]))
+            else:
+                raise ValueError("Could not open node config file using configuri")
+    else:
+        raise ValueError("Could not open node config file")
+
+except (ImportError, ValueError):
     # default reference position for MKAT array
     ref_location = 'ref, -30:42:47.4, 21:26:38.0, 1060.0, 0.0, , , 1.15'
 else:

--- a/astrokat/observatory.py
+++ b/astrokat/observatory.py
@@ -14,6 +14,7 @@ try:
     # Set up configuration sourcei
     config_path = '/var/kat/config'
     node_file = '/var/kat/node.conf'
+    settings = {}
     if os.path.isdir(config_path):
         katconf.set_config(katconf.environ(override=config_path))
     elif os.path.isfile(node_file):

--- a/astrokat/observatory.py
+++ b/astrokat/observatory.py
@@ -10,7 +10,7 @@ from utility import katpoint_target, lst2utc
 
 try:
     import katconf
-    # Set up configuration sourcei
+    # Set up configuration source
     _config_path = '/var/kat/config'
     _node_file = '/var/kat/node.conf'
     _settings = {}
@@ -43,6 +43,7 @@ else:
 
 # Basic LST calculations using ephem
 class Observatory(object):
+
     def __init__(self, location=None):
         self.location = _ref_location 
         self.node_config_available = _node_config_available

--- a/astrokat/observatory.py
+++ b/astrokat/observatory.py
@@ -19,10 +19,10 @@ try:
     elif os.path.isfile(_node_file):
         with open(_node_file, 'r') as fh:
             _node_conf = json.loads(fh.read())
-        for key, val in _node_conf.items():
+        for _key, _val in _node_conf.items():
             # Remove comments at the end of the line
-            val = val.split("#", 1)[0]
-            _settings[key] = val.strip()
+            _val = _val.split("#", 1)[0]
+            _settings[key] = _val.strip()
             if _node_conf.get("configuri", False):
                 katconf.set_config(katconf.environ(_node_conf["configuri"]))
             else:
@@ -79,7 +79,7 @@ class Observatory(object):
         self.observer.date = set_time
         return self.observer.sidereal_time()
 
-    def _read_file_from_node_config(self, catalogue_file):
+    def read_file_from_node_config(self, catalogue_file):
         if not self.node_config_available:
             raise AttributeError('Node config is not configured')
         else:

--- a/astrokat/observatory.py
+++ b/astrokat/observatory.py
@@ -22,7 +22,7 @@ try:
         for _key, _val in _node_conf.items():
             # Remove comments at the end of the line
             _val = _val.split("#", 1)[0]
-            _settings[key] = _val.strip()
+            _settings[_key] = _val.strip()
             if _node_conf.get("configuri", False):
                 katconf.set_config(katconf.environ(_node_conf["configuri"]))
             else:

--- a/astrokat/observatory.py
+++ b/astrokat/observatory.py
@@ -23,16 +23,16 @@ try:
             # Remove comments at the end of the line
             _val = _val.split("#", 1)[0]
             _settings[_key] = _val.strip()
-            if _node_conf.get("configuri", False):
-                katconf.set_config(katconf.environ(_node_conf["configuri"]))
-            else:
-                raise ValueError("Could not open node config file using configuri")
+        if _settings.get("configuri", False):
+            katconf.set_config(katconf.environ(_node_conf["configuri"]))
+        else:
+            raise ValueError("Could not open node config file using configuri")
     else:
         raise ValueError("Could not open node config file")
 
 except (ImportError, ValueError):
     # default reference position for MKAT array
-    _ref_location = 'ref, -30:42:47.4, 21:26:38.0, 1060.0, 0.0, , , 1.15'
+    _ref_location = 'ref, -30:42:39.8, 21:26:38.0, 1035.0, 0.0, , , 1.15'
     _node_config_available = False
 else:
     # default reference position for MKAT array from katconf

--- a/scripts/astrokat-cals.py
+++ b/scripts/astrokat-cals.py
@@ -24,14 +24,6 @@ try:
 except ImportError:  # not a processing node
     text_only = True
 
-# set up path and access method for calibrator catalogues
-#catalogue_path = '/var/kat/config/katconfig/user/catalogues'
-
-#try:
-#    import katconf
-#except ImportError:  # not on live system
-#    pass
-
 
 def cli(prog):
     version = "{} 0.1".format(prog)
@@ -69,12 +61,6 @@ Proposal ID")
             help='\
 List of tags for types of calibrators to provide per target: \
 gain, bandpass, flux, polarisation.')
-    parser.add_argument(
-            '--cal-catalogue-path',
-            type=str,
-            default='katconfig/user/catalogues',
-            help='\
-Path to directory containing calibrator catalogue files.')
     parser.add_argument(
             '--target',
             nargs=3,
@@ -308,8 +294,7 @@ def main(args):
         for cal_tag in args.cal_tags:
             cal_catalogue = os.path.join(
                     catalogue_path,
-                    'sources_pnt.csv',
-                    #'Lband-interferometric-{}-calibrators.csv'.format(cal_tag),
+                    'Lband-interferometric-{}-calibrators.csv'.format(cal_tag),
                     )
            
             if args.cat_path:

--- a/scripts/astrokat-cals.py
+++ b/scripts/astrokat-cals.py
@@ -7,6 +7,7 @@ import argparse
 import katpoint
 import numpy
 import os
+import json
 import sys
 
 from astrokat import Observatory

--- a/scripts/astrokat-cals.py
+++ b/scripts/astrokat-cals.py
@@ -280,7 +280,7 @@ def main(args):
                 calibrators = katpoint.Catalogue(file(cal_catalogue))
             elif node_config_available:
                 calibrators = katpoint.Catalogue(
-                    observatory._read_file_from_node_config(cal_catalogue))
+                    observatory.read_file_from_node_config(cal_catalogue))
             else:
                 raise RuntimeError('Loading calibrator catalogue {} failed!'.format(cal_catalogue))
 

--- a/scripts/astrokat-cals.py
+++ b/scripts/astrokat-cals.py
@@ -229,6 +229,7 @@ def main(args):
 
     cam_config_path = '/var/kat/config'
     node_file = '/var/kat/node.conf'
+    settings = {}
 
     try:
         import katconf
@@ -248,10 +249,9 @@ def main(args):
                     print('katconf config not set')
         else:
             raise ValueError("Could not open node config file")
-        config_available = True
+        node_config_available = True
     except ImportError:
-        config_available = False
-        pass  # not on live system
+        node_config_available = False
 
 
     location = Observatory().location
@@ -277,8 +277,10 @@ def main(args):
 
     if args.cat_path and os.path.isdir(args.cat_path):
         catalogue_path = args.cat_path
+        config_file_available = True
     else:
         catalogue_path = 'katconfig/user/catalogues'
+        config_file_available = False
 
     # input target from command line
     args.target = [target.strip() for target in args.target]
@@ -298,10 +300,10 @@ def main(args):
                     'Lband-{}-calibrators.csv'.format(cal_tag),
                     )
            
-            if args.cat_path:
+            if config_file_available:
                 assert os.path.isfile(cal_catalogue), 'Catalogue file does not exist'
                 calibrators = katpoint.Catalogue(file(cal_catalogue))
-            elif config_available:
+            elif node_config_available:
                 assert katconf.resource_exists(cal_catalogue), 'Catalogue file does not exist'
                 calibrators = katpoint.Catalogue(
                     katconf.resource_template(cal_catalogue))

--- a/scripts/astrokat-cals.py
+++ b/scripts/astrokat-cals.py
@@ -294,7 +294,7 @@ def main(args):
         for cal_tag in args.cal_tags:
             cal_catalogue = os.path.join(
                     catalogue_path,
-                    'Lband-interferometric-{}-calibrators.csv'.format(cal_tag),
+                    'Lband-{}-calibrators.csv'.format(cal_tag),
                     )
            
             if args.cat_path:


### PR DESCRIPTION
This PR is to add config reading to the astrokat-cals script if katconfig is available. First it will try the arg provided in --cat-path. If that is not a usable file, try the /var/kat/config path to find the file. If that path is not available, finally try to retrieve the config server uri from node conf and fetch the config that. 

I've added the bug label for now as the last case is not fully working. Testing on a node that can import katconf but does not have the /var/kat/config locally, the attempted import of the arrayconfig fails.