### PR TITLE
Fix integration test errors by adding setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,2 +1,10 @@
 from distutils.core import setup
-setup(name='astrokat', version='0.1', py_modules=['astrokat'])
+setup(
+    name='astrokat',
+    version='0.1',
+    py_modules=['astrokat'],
+    install_requires=['pyephem',
+                      'katpoint',
+                      'matplotlib',
+                      'numpy',
+                      'pyyaml'])

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,2 @@
+from distutils.core import setup
+setup(name='astrokat', version='0.1', py_modules=['astrokat'])


### PR DESCRIPTION
This package needs a setup.py to install as it's currently breaking our integration builds.
I added a very simple one just to get going, please expand as needed.

Error in integration tests:

```
Directory u'/home/kat/svn/astrokat' is not installable. File 'setup.py' not found.
Exception information:
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/pip/basecommand.py", line 215, in main
    status = self.run(options, args)
  File "/usr/local/lib/python2.7/dist-packages/pip/commands/install.py", line 312, in run
    wheel_cache
  File "/usr/local/lib/python2.7/dist-packages/pip/basecommand.py", line 295, in populate_requirement_set
    wheel_cache=wheel_cache):
  File "/usr/local/lib/python2.7/dist-packages/pip/req/req_file.py", line 93, in parse_requirements
    for req in req_iter:
  File "/usr/local/lib/python2.7/dist-packages/pip/req/req_file.py", line 158, in process_line
    isolated=isolated, options=req_options, wheel_cache=wheel_cache
  File "/usr/local/lib/python2.7/dist-packages/pip/req/req_install.py", line 201, in from_line
    "not found." % name
InstallationError: Directory u'/home/kat/svn/astrokat' is not installable. File 'setup.py' not found.
```