### PR TITLE
Add `katconf`, `katcorelib` as extra dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,4 +7,7 @@ setup(
                       'katpoint',
                       'matplotlib',
                       'numpy',
-                      'pyyaml'])
+                      'pyyaml'],
+    extras_require={
+        'live': ['katcorelib', 'katconf']
+    })


### PR DESCRIPTION
These additional packages are used in the live system but were not specified as dependencies.

I'm adding them as optional extras (can be installed using `pip install -e .[live]`). See [PEP508](https://www.python.org/dev/peps/pep-0508/) for more information.