### PR TITLE
Add katversion support and install scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 
 # /
+.eggs
 *.egg-info
 *.pyc
 *~

--- a/astrokat/__init__.py
+++ b/astrokat/__init__.py
@@ -23,4 +23,16 @@ from .observatory import (  # noqa
     collect_targets,
     )
 
+
+# BEGIN VERSION CHECK
+# Get package version when locally imported from repo or via -e develop install
+try:
+    import katversion as _katversion
+except ImportError:
+    import time as _time
+    __version__ = "0.0+unknown.{}".format(_time.strftime('%Y%m%d%H%M'))
+else:
+    __version__ = _katversion.get_version(__path__[0])
+# END VERSION CHECK
+
 # -fin-

--- a/astrokat/__main__.py
+++ b/astrokat/__main__.py
@@ -1,4 +1,8 @@
 import argparse
+
+import astrokat
+
+
 live_system = True
 try:
     from katcorelib.observe import (standard_script_options)
@@ -86,7 +90,6 @@ def cli(prog,
 
     if parser is None:
         # Set up standard script options
-        version = "%s 0.1" % prog
         # TODO: more complex usage string in separate function
         usage = "%s [options] -o <observer>" \
                 " --yaml <YAMLfile>" \
@@ -103,7 +106,7 @@ def cli(prog,
 
     # Standard track experiment options
     parser.add_argument('--version',
-                        action='version', version=version)
+                        action='version', version=astrokat.__version__)
     parser.add_argument('--yaml',
                         default=[],
                         type=str,

--- a/astrokat/observe_main.py
+++ b/astrokat/observe_main.py
@@ -28,7 +28,7 @@ finally:
     for libname in libnames:
         globals()[libname] = getattr(lib, libname)
 
-global TRACE
+TRACE = False
 
 
 # unpack targets to katpoint compatible format

--- a/scripts/astrokat-cals.py
+++ b/scripts/astrokat-cals.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # MeerKAT calibrator selection tools
 #  Returns the closest calibrator(s) for per target
 
@@ -10,7 +11,7 @@ import numpy
 import os
 import sys
 
-from astrokat import Observatory, read_yaml, katpoint_target
+from astrokat import Observatory, read_yaml, katpoint_target, __version__
 from astrokat.utility import datetime2timestamp, timestamp2datetime
 from datetime import datetime
 
@@ -26,7 +27,6 @@ except ImportError:  # not a processing node
 
 # define command line input arguments
 def cli(prog):
-    version = "{} 0.1".format(prog)
     usage = "{} [options]".format(prog)
     description = 'calibrator selection for MeerKAT telescope'
 
@@ -37,7 +37,7 @@ def cli(prog):
     parser.add_argument(
             '--version',
             action='version',
-            version=version)
+            version=__version__)
     parser.add_argument(
             '--pi',
             type=str,

--- a/scripts/astrokat-fitflux.py
+++ b/scripts/astrokat-fitflux.py
@@ -1,9 +1,12 @@
+#!/usr/bin/env python
 # Scaling flux calibrator coefficient to MHz
 # Reference: Perley & Butler 2017
 
 import argparse
 import numpy
 import matplotlib.pyplot as plt
+
+from astrokat import __version__
 
 # Listed frequencies used for fitting
 fit_frequencies_mhz = numpy.array([73.8, 232, 247, 275, 296, 312, 328, 344,
@@ -87,7 +90,6 @@ def coeffs_ghz2mhz(
 # scale coefficients by refitting the polynomial:
 #   python astrokat-fitflux.py --refit
 if __name__ == '__main__':
-    version = "%%prog 0.1"
     usage = "%%prog [options]"
     description = 'Scale flux model coefficients from GHz to MHz for MeerKAT telescope'
 
@@ -97,7 +99,7 @@ if __name__ == '__main__':
     parser.add_argument(
             '--version',
             action='version',
-            version=version)
+            version=__version__)
     parser.add_argument(
             '--refit',
             action='store_true',

--- a/scripts/astrokat-lst.py
+++ b/scripts/astrokat-lst.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # MeerKAT LST calculation helper tools
 
 import argparse
@@ -6,12 +7,11 @@ import katpoint
 import sys
 import time
 
-from astrokat import Observatory, lst2utc
+from astrokat import Observatory, lst2utc, __version__
 from datetime import datetime
 
 
 def cli(prog):
-    version = "{} 0.1".format(prog)
     usage = "{} [options]".format(prog)
     description = 'LST calculations for MeerKAT telescope'
 
@@ -21,7 +21,7 @@ def cli(prog):
     parser.add_argument(
             '--version',
             action='version',
-            version=version)
+            version=__version__)
     parser.add_argument(
             '--date',
             type=str,

--- a/scripts/catalogue2obsfile.py
+++ b/scripts/catalogue2obsfile.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # Take a catalogue file and construct a basic observation configuration file
 
 from __future__ import print_function

--- a/scripts/readconfig.py
+++ b/scripts/readconfig.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # Utility test script to verify json configuration files
 # Use after edit and before observation planning
 from pprint import pprint

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,40 @@
-from setuptools import setup
+#!/usr/bin/env python
+
+from setuptools import setup, find_packages
+
+
+with open('README.md') as readme:
+    long_description = readme.read()
+
 setup(
     name='astrokat',
-    version='0.1',
-    py_modules=['astrokat'],
+    description='Tools for astronomy observations with the MeerKAT telescope',
+    long_description=long_description,
+    author='Ruby van Rooyen / MeerKAT CAM team',
+    author_email='cam@ska.ac.za',
+    packages=find_packages(),
+    scripts=[
+        'scripts/astrokat-cals.py',
+        'scripts/astrokat-fitflux.py',
+        'scripts/astrokat-lst.py',
+        'scripts/astrokat-observe.py',
+    ],
+    url='https://github.com/ska-sa/astrokat',
+    license='BSD 2-Clause',
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: BSD License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python :: 2.7',
+        'Topic :: Software Development :: Libraries :: Python Modules',
+        'Topic :: Scientific/Engineering :: Astronomy',
+    ],
+    platforms=['OS Independent'],
+    keywords='meerkat ska',
+    zip_safe=False,
+    setup_requires=['katversion'],
+    use_katversion=True,
     install_requires=['pyephem',
                       'katpoint',
                       'matplotlib<3',
@@ -11,4 +43,10 @@ setup(
                       'nose-testconfig'],
     extras_require={
         'live': ['katcorelib', 'katconf']
-    })
+    },
+    tests_require=['nose',
+                   'nose-testconfig',
+                   'coverage',
+                   'nosexcover',
+                   'unittest2'],
+)


### PR DESCRIPTION
- Add _katversion_ so that we can get version strings derived from the git version info.  This is required for CAM's automated branch creation tool.
- Install the useful scripts so that they are available on the path.
- Add some more details to setup.py.

Closes issue #14