### PR TITLE
pin numpy to versions with py2 support < 1.17

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     install_requires=['pyephem',
                       'katpoint',
                       'matplotlib<3',
-                      'numpy<1.17',
+                      'numpy>=1.17' if sys.version_info >= (3, 5) else 'numpy<1.17',
                       'pyyaml'],
     extras_require={
         'live': ['katcorelib', 'katconf']

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     install_requires=['pyephem',
                       'katpoint',
                       'matplotlib<3',
-                      'numpy',
+                      'numpy<1.17',
                       'pyyaml'],
     extras_require={
         'live': ['katcorelib', 'katconf']

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import sys
 from setuptools import setup, find_packages
 
 


### PR DESCRIPTION
Numpy's 1.17 pre-release has dropped support to python 2. See numpy [repo](https://github.com/numpy/numpy/releases/tag/v1.17.0rc1).

This PR is to ensure that the numpy install < v1.17 for py2 and >=v1.17 for py3.