### PR TITLE
Remove hard coded cal tags

### DIFF
--- a/astrokat/observe_main.py
+++ b/astrokat/observe_main.py
@@ -283,8 +283,8 @@ class Telescope(object):
             return
         approved_sb_sensor_value = approved_sb_sensor.get_value()
         if self.array.sb_id_code not in approved_sb_sensor_value:
-            user_logger.info('Skipping instrument checks - {} not in approved_schedule'
-                             .format(self.array.sb_id_code))
+            user_logger.info('Skipping instrument checks - {} not in approved_schedule'.format(
+                self.array.sb_id_code))
             return
 
         for key in instrument.keys():
@@ -334,6 +334,11 @@ def run_observation(opts, kat):
     if 'durations' in obs_plan_params:
         if 'obs_duration' in obs_plan_params['durations']:
             obs_duration = obs_plan_params['durations']['obs_duration']
+    # check for nonsensical observation duration setting
+    if obs_duration < 1e-5:
+        user_logger.error('Unexpected value: obs_duration: {}'.format(
+            obs_duration))
+        return
 
     # Each observation loop contains a number of observation cycles over LST ranges
     # For a single observation loop, only a start LST and duration is required
@@ -347,6 +352,7 @@ def run_observation(opts, kat):
         target_list = obs_targets['target'].tolist()
         # build katpoint catalogues for tidy handling of targets
         catalogue = collect_targets(kat.array, target_list)
+        obs_tags = []
         for tgt in obs_targets:
             # catalogue names are no longer unique
             name = tgt['name']
@@ -356,7 +362,9 @@ def run_observation(opts, kat):
                 if (name == cat_tgt.name and
                         tags == ' '.join(cat_tgt.tags)):
                     tgt['target'] = cat_tgt
+                    obs_tags.extend(cat_tgt.tags)
                     break
+        cal_tags = np.unique([tag for tag in obs_tags if 'cal' in tag])
 
         # observer object handle to track the observation timing in a more user friendly way
         observer = catalogue._antenna.observer
@@ -376,24 +384,20 @@ def run_observation(opts, kat):
             if opts.all_up and (len(catalogue.filter(el_limit_deg=opts.horizon)) != len(catalogue)):
                 raise NotAllTargetsUpError('Not all targets are currently visible - '
                                            'please re-run the script with --visibility for information')
-        cal_tags = {'Polarisation': 'polcal',
-                    'Flux': 'fluxcal',
-                    'Bandpass': 'bpcal',
-                    'Gain': 'gaincal',
-                    'Delay': 'delaycal',
-                    }
-        target_tags = []
-        for cal_type in cal_tags.keys():
-            target_tags.append('~{}'.format(cal_tags[cal_type]))
-            cal_array = [repr(cal.name) for cal in catalogue.filter(cal_tags[cal_type])]
+        # List sources and their associated functions from observation tags
+        not_cals_filter_list = []
+        for cal_type in cal_tags:
+            not_cals_filter_list.append('~{}'.format(cal_type))
+            cal_array = [repr(cal.name) for cal in catalogue.filter(cal_type)]
             if len(cal_array) < 1:
                 continue  # do not display empty tags
             cal_list = ', '.join(cal_array)
             user_logger.info("{} calibrators are [{}]".format(
-                             cal_type,
+                             str.upper(cal_type.replace('cal', '')),
                              cal_list))
-        user_logger.info('Imaging targets are [{}]'.format(
-                         ', '.join([repr(target.name) for target in catalogue.filter(target_tags)])))
+        user_logger.info('Observation targets are [{}]'.format(
+            ', '.join([repr(target.name) for target in catalogue.filter(
+                not_cals_filter_list)])))
 
         # TODO: the description requirement in sessions should be re-evaluated
         # since the schedule block has the description

--- a/astrokat/observe_main.py
+++ b/astrokat/observe_main.py
@@ -334,11 +334,6 @@ def run_observation(opts, kat):
     if 'durations' in obs_plan_params:
         if 'obs_duration' in obs_plan_params['durations']:
             obs_duration = obs_plan_params['durations']['obs_duration']
-    # check for nonsensical observation duration setting
-    if obs_duration < 1e-5:
-        user_logger.error('Unexpected value: obs_duration: {}'.format(
-            obs_duration))
-        return
 
     # Each observation loop contains a number of observation cycles over LST ranges
     # For a single observation loop, only a start LST and duration is required

--- a/astrokat/observe_main.py
+++ b/astrokat/observe_main.py
@@ -360,7 +360,7 @@ def run_observation(opts, kat):
                     obs_tags.extend(cat_tgt.tags)
                     break
         obs_tags = list(set(obs_tags))
-        cal_tags = [tag for tag in obs_tags if 'cal' in tag]
+        cal_tags = [tag for tag in obs_tags if tag[-3:] == 'cal']
 
         # observer object handle to track the observation timing in a more user friendly way
         observer = catalogue._antenna.observer
@@ -384,13 +384,12 @@ def run_observation(opts, kat):
         not_cals_filter_list = []
         for cal_type in cal_tags:
             not_cals_filter_list.append('~{}'.format(cal_type))
-            cal_array = [repr(cal.name) for cal in catalogue.filter(cal_type)]
+            cal_array = [cal.name for cal in catalogue.filter(cal_type)]
             if len(cal_array) < 1:
                 continue  # do not display empty tags
-            cal_list = ', '.join(cal_array)
-            user_logger.info("{} calibrators are [{}]".format(
-                             str.upper(cal_type.replace('cal', '')),
-                             cal_list))
+            user_logger.info("{} calibrators are {}".format(
+                             str.upper(cal_type[:-3]),
+                             cal_array))
         user_logger.info('Observation targets are [{}]'.format(
             ', '.join([repr(target.name) for target in catalogue.filter(
                 not_cals_filter_list)])))

--- a/astrokat/observe_main.py
+++ b/astrokat/observe_main.py
@@ -359,7 +359,8 @@ def run_observation(opts, kat):
                     tgt['target'] = cat_tgt
                     obs_tags.extend(cat_tgt.tags)
                     break
-        cal_tags = np.unique([tag for tag in obs_tags if 'cal' in tag])
+        obs_tags = list(set(obs_tags))
+        cal_tags = [tag for tag in obs_tags if 'cal' in tag]
 
         # observer object handle to track the observation timing in a more user friendly way
         observer = catalogue._antenna.observer

--- a/astrokat/test/test_offline_observe.py
+++ b/astrokat/test/test_offline_observe.py
@@ -30,11 +30,8 @@ class TestAstrokatYAML(unittest.TestCase):
         # get result and make sure everything ran properly
         result = LoggedTelescope.user_logger_stream.getvalue()
         self.assertIn("Single run through observation target list", result)
-        self.assertIn(
-            "Bandpass calibrators are ['1934-638', '0408-65']",
-            result,
-            "two Bandpass calibrators",
-        )
+        self.assertIn("BP calibrators are ['1934-638', '0408-65']", result,
+                      "two Bandpass calibrators")
 
         cal1 = result.count("0408-65 observed for 30.0 sec")
         cal2 = result.count("1934-638 observed for 30.0 sec")
@@ -71,14 +68,17 @@ class TestAstrokatYAML(unittest.TestCase):
         result = LoggedTelescope.user_logger_stream.getvalue()
         self.assertIn("Single run through observation target list", result)
         expected_results = (
-            "Imaging targets are ['T3R04C06', 'T4R00C02', 'T4R00C04', 'T4R00C06',"
-            " 'T4R01C01', 'T4R01C03', 'T4R01C05', 'T4R02C02', 'T4R02C04']"
+            "Observation targets are ['T3R04C06', 'T4R00C02', 'T4R00C04', 'T4R00C06', "
+            "'T4R01C01', 'T4R01C03', 'T4R01C05', 'T4R02C02', 'T4R02C04']"
         )
         self.assertIn(expected_results, result, "Nine imaging targets")
-        self.assertIn("Bandpass calibrators are ['1934-638', '3C286']", result,
-            "two bandpass calibrators"
-        )
-        self.assertIn("Gain calibrators are ['1827-360']", result, "one gain calibrator")
+
+        self.assertIn("BP calibrators are ['1934-638', '3C286']", result,
+                      "two bandpass calibrators")
+        self.assertIn("GAIN calibrators are ['1827-360']", result, "one gain calibrator")
+        self.assertIn("POL calibrators are ['3C286']", result, "one pol calibrator")
+        self.assertIn("DELAY calibrators are ['1934-638']", result, "one delay calibrator")
+
         self.assertIn("1827-360 observed for 30.0 sec", result)
         self.assertIn("1934-638 observed for 120.0 sec", result)
         self.assertIn("3C286 observed for 40.0 sec", result)
@@ -104,16 +104,16 @@ class TestAstrokatYAML(unittest.TestCase):
         )
 
         expected_results = (
-            "Imaging targets are ['T3R04C06', 'T4R00C02', 'T4R00C04', 'T4R00C06',"
-            " 'T4R01C01', 'T4R01C03', 'T4R01C05', 'T4R02C02', 'T4R02C04']"
+            "Observation targets are ['T3R04C06', 'T4R00C02', 'T4R00C04', 'T4R00C06', "
+            "'T4R01C01', 'T4R01C03', 'T4R01C05', 'T4R02C02', 'T4R02C04']"
         )
         self.assertIn(expected_results, result, "Nine imaging targets")
 
-        self.assertIn("Bandpass calibrators are ['1934-638', '3C286']", result,
-            "two bandpass calibrators",
-        )
-
-        self.assertIn("Gain calibrators are ['1827-360']", result, "one gain calibrator")
+        self.assertIn("GAIN calibrators are ['1827-360']", result, "one gain calibrator")
+        self.assertIn("BP calibrators are ['1934-638', '3C286']", result,
+                      "two BP calibrator")
+        self.assertIn("DELAY calibrators are ['1934-638']", result, "one dealy calibrator")
+        self.assertIn("POL calibrators are ['3C286']", result, "one pol calibrator")
         self.assertIn("1827-360 observed for 30.0 sec", result)
         self.assertIn("1934-638 observed for 120.0 sec", result)
         self.assertIn("3C286 observed for 80.0 sec", result)


### PR DESCRIPTION
Remove hardcoded dictionary of calibrator tags
Updated with code that extract all unique cal tags and use those to display output to user, thus whatever is in the YAML is displayed, making the code independent of user defined tags

New output:
```
2019-07-30 07:03:41Z - Found 5 target(s): 0 from 0 catalogue(s), 0 from default catalogue and 37 as target string(s)
2019-07-30 07:03:41Z - BP calibrators are ['J0408-6545']
2019-07-30 07:03:41Z - DELAY calibrators are ['J0408-6545']
2019-07-30 07:03:41Z - FLUX calibrators are ['J0408-6545']
2019-07-30 07:03:41Z - GAIN calibrators are ['J0632+1022', 'J1150-0023']
2019-07-30 07:03:41Z - Observation targets are ['3C 175', '3C 274']
```