### PR TITLE
add check for obs_duration=0

### DIFF
--- a/astrokat/observe_main.py
+++ b/astrokat/observe_main.py
@@ -334,6 +334,11 @@ def run_observation(opts, kat):
     if 'durations' in obs_plan_params:
         if 'obs_duration' in obs_plan_params['durations']:
             obs_duration = obs_plan_params['durations']['obs_duration']
+    # check for nonsensical observation duration setting
+    if obs_duration < 1e-5:
+        user_logger.error('Unexpected value: obs_duration: {}'.format(
+            obs_duration))
+        return
 
     # Each observation loop contains a number of observation cycles over LST ranges
     # For a single observation loop, only a start LST and duration is required

--- a/astrokat/observe_main.py
+++ b/astrokat/observe_main.py
@@ -335,7 +335,7 @@ def run_observation(opts, kat):
         if 'obs_duration' in obs_plan_params['durations']:
             obs_duration = obs_plan_params['durations']['obs_duration']
     # check for nonsensical observation duration setting
-    if obs_duration < 1e-5:
+    if  abs(obs_duration) < 1e-5:
         user_logger.error('Unexpected value: obs_duration: {}'.format(
             obs_duration))
         return

--- a/astrokat/utility.py
+++ b/astrokat/utility.py
@@ -28,7 +28,7 @@ def read_yaml(filename):
         return {}
 
     # remove empty keys
-    for key in data.keys():
+    for key in list(data.keys()):
         if data[key] is None:
             del data[key]
 

--- a/astrokat/utility.py
+++ b/astrokat/utility.py
@@ -27,6 +27,11 @@ def read_yaml(filename):
         # not a yaml file, suspected csv file, returning False
         return {}
 
+    # remove empty keys
+    for key in data.keys():
+        if data[key] is None:
+            del data[key]
+
     # handle mapping of user friendly keys to CAM resource keys
     if 'instrument' in data.keys():
         instrument = data['instrument']


### PR DESCRIPTION
Add check to exit if obs_duration is zero

New output:
```
> astrokat-observe.py --yaml tagtest.yaml
2019-07-30 14:44:54Z - Setting up telescope for observation
2019-07-30 14:44:54Z - Running astrokat version - 0.0+unknown.201907301644
2019-07-30 14:44:54Z - Request: Switch noise-diode off at 1564497900.0
2019-07-30 14:44:54Z - Dry-run: Set all noise diodes with timestamp 1564497900.0 (Tue Jul 30 16:45:00 2019)
2019-07-30 14:44:54Z - Unexpected value: obs_duration: 0.0
2019-07-30 14:44:54Z - Returning telescope to startup state
2019-07-30 14:44:54Z - Request: Switch noise-diode off at 1564497900.0
2019-07-30 14:44:54Z - Dry-run: Set all noise diodes with timestamp 1564497900.0 (Tue Jul 30 16:45:00 2019)
```