### PR TITLE
Automate code linting and reject PR if fails.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
     }
 
     stages {
-        stage('Checkout SCM') {
+        stage ('Checkout SCM') {
             steps {
                 checkout([
                     $class: 'GitSCM',
@@ -24,6 +24,7 @@ pipeline {
         stage ('Static analysis') {
             steps {
                 sh "pylint ./${KATPACKAGE} --output-format=parseable --exit-zero > pylint.out"
+                sh "lint_diff.sh -r ${KATPACKAGE}"
             }
 
             post {
@@ -33,7 +34,7 @@ pipeline {
             }
         }
 
-        stage('Install & Unit Tests') {
+        stage ('Install & Unit Tests') {
             options {
                 timestamps()
                 timeout(time: 30, unit: 'MINUTES')
@@ -44,14 +45,14 @@ pipeline {
             }
 
             parallel {
-                stage('py27') {
+                stage ('py27') {
                     steps {
                         echo "Running nosetests on Python 2.7"
                         sh 'tox -e py27'
                     }
                 }
 
-                stage('py36') {
+                stage ('py36') {
                     steps {
                         echo "Running nosetests on Python 3.6"
                         sh 'tox -e py36'
@@ -83,7 +84,7 @@ pipeline {
             }
         }
 
-        stage('Build & publish packages') {
+        stage ('Build & publish packages') {
             when {
                 branch 'master'
             }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,47 @@
+# Project configuration file
+
+# NOTE: you have to use single-quoted strings in TOML for regular expressions.
+# It's the equivalent of r-strings in Python.  Multiline strings are treated as
+# verbose regular expressions by Black.  Use [ ] to denote a significant space
+# character.
+
+[tool.black]
+# See: https://docs.google.com/document/d/1aZoIyR9tz5rCWr2qJKuMTmKp2IzHlFjrCFrpDDHFypM/edit#heading=h.95alkrtwtub0
+line-length = 90
+target-version = ['py27', 'py36']
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.eggs
+    | \.git
+    | \.__pycache__
+    | \.mypy_cache
+    | \.tox
+    | \.venv
+    | \.env
+    | _build
+    | buck-out
+    | build
+    | dist
+)/
+'''
+
+[tool.isort]
+force_grid_wrap = 0
+include_trailing_comma = true
+indent = 4
+line_length = 90
+multi_line_output = 3
+# Having imports glued together is physically painful. ;)
+lines_between_types = 1
+# Imports sections
+sections = ['FUTURE', 'STDLIB', 'THIRDPARTY', 'FIRSTPARTY', 'LOCALFOLDER']
+# A list of known imports that will be forced to display within their specified category.
+known_first_party = [
+    'astrokat', 'katcapture', 'katcomp', 'katconf', 'katcore', 'katcorelib', 'katcp',
+    'katdeploy', 'katgui', 'katlogger', 'katmisc', 'katnodeman', 'katobs', 'katopc',
+    'katpoint', 'katportal', 'katportalclient', 'katproxy', 'katscripts', 'katsdisp',
+    'katsdpcatalogues', 'katsdpcontroller', 'katsdpscripts', 'katsdpservices',
+    'katsdptelstate', 'katsim', 'katuilib', 'katusescripts', 'katversion', 'mkat_tango', 'mkatstore',
+    'nosekatreport', 'pylibmodbus', 'spead', 'tango_simlib'
+    ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,10 +38,6 @@ lines_between_types = 1
 sections = ['FUTURE', 'STDLIB', 'THIRDPARTY', 'FIRSTPARTY', 'LOCALFOLDER']
 # A list of known imports that will be forced to display within their specified category.
 known_first_party = [
-    'astrokat', 'katcapture', 'katcomp', 'katconf', 'katcore', 'katcorelib', 'katcp',
-    'katdeploy', 'katgui', 'katlogger', 'katmisc', 'katnodeman', 'katobs', 'katopc',
-    'katpoint', 'katportal', 'katportalclient', 'katproxy', 'katscripts', 'katsdisp',
-    'katsdpcatalogues', 'katsdpcontroller', 'katsdpscripts', 'katsdpservices',
-    'katsdptelstate', 'katsim', 'katuilib', 'katusescripts', 'katversion', 'mkat_tango', 'mkatstore',
-    'nosekatreport', 'pylibmodbus', 'spead', 'tango_simlib'
+    'astrokat', 'katcp', 'katpoint', 'katportalclient', 'katversion', 'nosekatreport',
+    'tango_simlib'
     ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,30 @@
 [nosetests]
-verbosity=3
-detailed-errors=1
-with-xunit=1
+verbosity = 3
+detailed-errors = 1
+with-xunit = 1
+
+[flake8]
+max-line-length = 90
+max-doc-length = 90
+docstring-convention = numpy
+statistics = True
+show-source = True
+; Print the total number of errors.
+count = True
+; max-complexity = 10
+; List of checks to ignore
+; D401 First line should be in imperative mood; try rephrasing
+; W503: line break before binary operator (This is incompartible with Black,
+;       See: https://black.readthedocs.io/en/stable/the_black_code_style.html#line-breaks-binary-operators)
+ignore = D401,W503
+exclude = *.egg/*,build,dist,__pycache__,.mypy_cache,.pytest_cache,__init__.py,docs/*.py
+; C errors are not selected by default, so add them to your selection
+select = B,C,D,E,F,I,W
+
+[pydocstyle]
+convention = numpy
+match = .*\.py
+inherit = false
+; List of checks to ignore
+; D401: First line should be in imperative mood. According to https://github.com/google/styleguide/blob/gh-pages/pyguide.md this rule is disabled.
+add-ignore = D401


### PR DESCRIPTION
This commit does the following:

- Added default setup.cfg (Refer to [CAM Developer's Guide](https://docs.google.com/document/d/1aZoIyR9tz5rCWr2qJKuMTmKp2IzHlFjrCFrpDDHFypM/edit#heading=h.whqqrvn0pw8f) which adds PEP8 strictness.)
- Added pyproject.toml config file which contains isort and black configurations/parameters.
- Added linting to static analysis stage on Jenkins

JIRA: [MT-1063](https://skaafrica.atlassian.net/browse/MT-1063)
