### PR TITLE
Include acceleration in slew time estimation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,4 @@ nosetests.xml
 .idea/
 .pyenv*/
 
-venv/
-venv2/
+venv*/

--- a/astrokat/simulate.py
+++ b/astrokat/simulate.py
@@ -219,7 +219,6 @@ class SimSession(object):
         user_logger.info("Slewed to %s at azel (%.1f, %.1f) deg", target.name, az, el)
         time.sleep(duration)
         user_logger.info("Tracked %s for %d seconds", target.name, duration)
-        self.katpt_current = target
         return True
 
     def raster_scan(
@@ -311,6 +310,7 @@ class SimSession(object):
             else:
                 user_logger.debug("Slewing to {}".format(target.name))
                 slew_time = self._slew_time(az, el)
+            self.katpt_current = target
         return slew_time, az, el
 
     def _slew_time(self, new_az, new_el):

--- a/astrokat/test/test_nd_timings.py
+++ b/astrokat/test/test_nd_timings.py
@@ -2,7 +2,8 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-import unittest2 as unittest
+import unittest
+
 from mock import patch
 
 from .testutils import LoggedTelescope, execute_observe_main

--- a/astrokat/test/test_offline_observe.py
+++ b/astrokat/test/test_offline_observe.py
@@ -2,7 +2,8 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-import unittest2 as unittest
+import unittest
+
 from mock import patch
 
 from .testutils import LoggedTelescope, execute_observe_main

--- a/astrokat/test/test_simulate.py
+++ b/astrokat/test/test_simulate.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 import unittest
 
+from collections import namedtuple
 from datetime import datetime
 
 import ephem
@@ -30,7 +31,7 @@ class TestSimSession(unittest.TestCase):
     def test__fake_slew_first_target_takes_default_time(self):
         target = self.azel_target(32.0, 64.0)
         slew_time, _, _ = self.DUT._fake_slew_(target)
-        self.assertAlmostEqual(slew_time, simulate._DEFAULT_SLEW_TIME)
+        self.assertAlmostEqual(slew_time, simulate._DEFAULT_SLEW_TIME_SEC)
 
     def test__fake_slew_same_target_takes_zero_time(self):
         target = self.azel_target(32.0, 64.0)
@@ -51,3 +52,25 @@ class TestSimSession(unittest.TestCase):
         _, az, el = self.DUT._fake_slew_(target)
         self.assertAlmostEqual(az, 32.0)
         self.assertAlmostEqual(el, 64.0)
+
+    def test__slew_time(self):
+        # test data generated from reference implementation in radec2azel.py
+        # script - see JIRA MT-1206
+        Data = namedtuple("Data", "az1 el1 az2 el2 slew_time")
+        tests = [
+            Data(az1=0.0, el1=40.0, az2=0.0, el2=40.0, slew_time=2.3),  # same target
+            Data(az1=0.0, el1=40.0, az2=0.5, el2=40.0, slew_time=4.3),  # tiny az slew
+            Data(az1=0.0, el1=40.0, az2=5.0, el2=40.0, slew_time=12.9),  # medium az slew
+            Data(az1=0.0, el1=40.0, az2=20.0, el2=40.0, slew_time=20.4),  # long +az slew
+            Data(az1=0.0, el1=40.0, az2=-20.0, el2=40.0, slew_time=20.4),  # long -az slew
+            Data(az1=0.0, el1=40.0, az2=0.0, el2=40.5, slew_time=5.13),  # tiny el slew
+            Data(az1=0.0, el1=40.0, az2=0.0, el2=45.0, slew_time=9.3),  # medium el slew
+            Data(az1=0.0, el1=40.0, az2=0.0, el2=60.0, slew_time=32.4),  # long +el slew
+            Data(az1=0.0, el1=40.0, az2=0.0, el2=20.0, slew_time=32.4),  # long -el slew
+            Data(az1=275.0, el1=40.0, az2=-180.0, el2=40.0, slew_time=57.9),  # > 180 az
+        ]
+        for test in tests:
+            initial_target = self.azel_target(test.az1, test.el1)
+            self.DUT._fake_slew_(initial_target)
+            slew_time = self.DUT._slew_time(test.az2, test.el2)
+            self.assertAlmostEqual(slew_time, test.slew_time, places=2)

--- a/astrokat/test/test_simulate.py
+++ b/astrokat/test/test_simulate.py
@@ -1,0 +1,53 @@
+"""Test astrokat simulation."""
+from __future__ import absolute_import
+from __future__ import print_function
+
+import unittest
+
+from datetime import datetime
+
+import ephem
+import katpoint
+import mock
+
+from astrokat import simulate, observatory
+
+
+class TestSimSession(unittest.TestCase):
+    def setUp(self):
+        start_time = datetime.strptime("2018-12-07 05:00:00", "%Y-%m-%d %H:%M:%S")
+        observer = ephem.Observer()
+        observer.date = ephem.Date(start_time)
+        simulate.setobserver(observer)
+        self.antenna = katpoint.Antenna(observatory._ref_location)
+        self.mock_kat = mock.Mock()
+        self.mock_kat.obs_params = {"durations": {"start_time": start_time}}
+        self.DUT = simulate.SimSession(self.mock_kat)
+
+    def azel_target(self, az, el):
+        return katpoint.Target("test, azel, {}, {}".format(az, el), antenna=self.antenna)
+
+    def test__fake_slew_first_target_takes_default_time(self):
+        target = self.azel_target(32.0, 64.0)
+        slew_time, _, _ = self.DUT._fake_slew_(target)
+        self.assertAlmostEqual(slew_time, simulate._DEFAULT_SLEW_TIME)
+
+    def test__fake_slew_same_target_takes_zero_time(self):
+        target = self.azel_target(32.0, 64.0)
+        self.DUT._fake_slew_(target)
+        slew_time, _, _ = self.DUT._fake_slew_(target)
+        self.assertAlmostEqual(slew_time, 0.0)
+
+    def test__fake_slew_new_target_takes_slew_time(self):
+        target1 = self.azel_target(32.0, 64.0)
+        target2 = self.azel_target(48.0, 80.0)
+        self.DUT._fake_slew_(target1)
+        expected_slew_time = self.DUT._slew_time(48, 80)
+        slew_time, _, _ = self.DUT._fake_slew_(target2)
+        self.assertAlmostEqual(slew_time, expected_slew_time)
+
+    def test__fake_slew_azel_returns_correct_az_el(self):
+        target = self.azel_target(32.0, 64.0)
+        _, az, el = self.DUT._fake_slew_(target)
+        self.assertAlmostEqual(az, 32.0)
+        self.assertAlmostEqual(el, 64.0)

--- a/tox.ini
+++ b/tox.ini
@@ -16,4 +16,3 @@ deps =
     mock
     nose
     nosexcover
-    unittest2


### PR DESCRIPTION
Improve slew time estimation by taking the mechanical accelerations into account, and combine that with some empirically modelled parameters.

Thanks to @vasaantk for the analysis and reference implementation of the updated slew calculations.

JIRA: [MT-1206](https://skaafrica.atlassian.net/browse/MT-1206)