### PR TITLE
set timezone of start_time parsed by yaml to None

### DIFF
--- a/astrokat/test/test_obs/image-single-sim.yaml
+++ b/astrokat/test/test_obs/image-single-sim.yaml
@@ -3,7 +3,7 @@ instrument:
   band: l
   integration_time: 8
 durations:
-  start_time: 2019-02-11 02:10:47
+  start_time: 2019-02-11 02:10:47Z
 observation_loop:
   - LST: 11.140-23.248
     target_list:

--- a/astrokat/test/test_obs/raster-scans-sim.yaml
+++ b/astrokat/test/test_obs/raster-scans-sim.yaml
@@ -4,7 +4,7 @@ instrument:
   product: c856M4k
   integration_time: 2
 durations:
-  start_time: 2018-10-31 14:00
+  start_time: 2018-10-31 14:00Z
   # > python astrokat-lst.py --lst 18.
   # 2018-10-31 18.0 LST corresponds to 2018-10-31 13:56:00Z UTC
   obs_duration: 120.

--- a/astrokat/test/test_obs/targets-sim.yaml
+++ b/astrokat/test/test_obs/targets-sim.yaml
@@ -1,7 +1,7 @@
 instrument:
   product: c856M4k
 durations:
-  start_time: 2018-07-23 18:00:00
+  start_time: 2018-07-23 18:00:00Z
 observation_loop:
   - LST: 0.0-23.9
     target_list:

--- a/astrokat/utility.py
+++ b/astrokat/utility.py
@@ -91,7 +91,7 @@ def datetime2timestamp(datetime_obj):
 
     """
     epoch = datetime.datetime.utcfromtimestamp(0)
-    return (datetime_obj - epoch).total_seconds()
+    return (datetime_obj.replace(tzinfo=None) - epoch).total_seconds()
 
 
 def timestamp2datetime(timestamp):


### PR DESCRIPTION
when yaml loads the file, it converted start_time to date with timezone if the data string has 'Z' in it. Need to remove the timezone, or will get error:
TypeError: can't subtract offset-naive and offset-aware datetimes

