### PR TITLE
catalogue debuggings have incorrect timing.

### DIFF
--- a/astrokat/observatory.py
+++ b/astrokat/observatory.py
@@ -263,7 +263,6 @@ def collect_targets(kat, args):
     from_names = from_strings = from_catalogues = num_catalogues = 0
     catalogue = katpoint.Catalogue()
     catalogue.antenna = katpoint.Antenna(_ref_location)
-    catalogue.antenna.observer.date = lst2utc(kat._lst, _ref_location)
 
     setobserver(catalogue.antenna.observer)
 


### PR DESCRIPTION
[MT-1257: Timestamp in astrokat during simulate](https://skaafrica.atlassian.net/browse/MT-1257)

Fixing last of the simulation logging timing issue.  Cataglue does not need a date. 