### PR TITLE
fix install on ubuntu 20 problem

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,6 @@ setup(
     zip_safe=False,
     setup_requires=["katversion"],
     use_katversion=True,
-    install_requires=["pyephem", "katpoint", "matplotlib<3", "numpy", "pyyaml"],
+    install_requires=["pyephem", "katpoint", "matplotlib", "numpy", "pyyaml"],
     extras_require={"live": ["katcorelib", "katconf"]},
 )


### PR DESCRIPTION
matplotlib<3 can't be installed on ubuntu 20.xx. This won't effect simulation and observation.
Just need to make sure users use ubuntu>20 if they want to use plotting utilities of astrokat.