### PR TITLE
fix noise diode failing in simulation

### DIFF
--- a/astrokat/noisediode.py
+++ b/astrokat/noisediode.py
@@ -69,7 +69,7 @@ def _set_dig_nd_(kat,
                        nd_antennas))
         user_logger.info(msg)
     else:
-        nd_antennas = sorted(ant.name for ant in kat.ants)
+        nd_antennas = sorted(ant for ant in kat.ants)
         cycle_length = 1.
         on_fraction = switch
 
@@ -399,7 +399,7 @@ def pattern(kat,
     user_logger.warning(msg)
 
     nd_antennas = nd_setup['antennas']
-    sb_ants = ",".join(str(ant.name) for ant in kat.ants)
+    sb_ants = ",".join(ant for ant in kat.ants)
     nd_setup['antennas'] = sb_ants
     if nd_antennas == 'all':
         cycle = False

--- a/astrokat/simulate.py
+++ b/astrokat/simulate.py
@@ -101,7 +101,7 @@ class SimKat(object):
         self._lst, _ = get_lst(self.obs_params["observation_loop"][0]["LST"])
         self._sensors = self.fake_sensors(kwargs)
         self._session_cnt = 0
-        self._ants = ["m011", "m022", "m033", "m044"]
+        self.ants = ["m011", "m022", "m033", "m044"]
 
     def __enter__(self):
         return self


### PR DESCRIPTION
fix noise diode failing in simulation and make sure all unit tests pass

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/katsdpopt/observation.py", line 1418, in simulate_ob
    verify_result = await verify_obs(script_profile_config, start_date)
  File "/usr/local/lib/python3.8/dist-packages/katsdpopt/astrokat_service.py", line 43, in verify_obs
    observe_main.main(['--yaml', fp.name])
  File "/usr/local/lib/python3.8/dist-packages/astrokat/observe_main.py", line 916, in main
    with Telescope(opts) as kat:
  File "/usr/local/lib/python3.8/dist-packages/astrokat/observe_main.py", line 327, in __enter__
    noisediode.off(self.array)
  File "/usr/local/lib/python3.8/dist-packages/astrokat/noisediode.py", line 259, in off
    true_timestamp = _switch_on_off_(kat, timestamp)
  File "/usr/local/lib/python3.8/dist-packages/astrokat/noisediode.py", line 186, in _switch_on_off_
    timestamp = _set_dig_nd_(kat,
  File "/usr/local/lib/python3.8/dist-packages/astrokat/noisediode.py", line 72, in _set_dig_nd_
    nd_antennas = sorted(ant.name for ant in kat.ants)
  File "/usr/local/lib/python3.8/dist-packages/astrokat/noisediode.py", line 72, in <genexpr>
    nd_antennas = sorted(ant.name for ant in kat.ants)
RuntimeError: generator raised StopIteration
```
