### PR TITLE
replace StopIteration with empty return in __iter__ function

### DIFF
--- a/astrokat/simulate.py
+++ b/astrokat/simulate.py
@@ -116,7 +116,7 @@ class SimKat(object):
         Ant = namedtuple("Ant", ["name"])
         for ant in self._ants:
             yield Ant(ant)
-        raise StopIteration
+        return
 
     def __exit__(self, type, value, traceback):
         pass


### PR DESCRIPTION
Fixing simulation error reported by Xinyu
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/katsdpopt/observation.py", line 1418, in simulate_ob
    verify_result = await verify_obs(script_profile_config, start_date)
  File "/usr/local/lib/python3.8/dist-packages/katsdpopt/astrokat_service.py", line 43, in verify_obs
    observe_main.main(['--yaml', fp.name])
  File "/usr/local/lib/python3.8/dist-packages/astrokat/observe_main.py", line 916, in main
    with Telescope(opts) as kat:
  File "/usr/local/lib/python3.8/dist-packages/astrokat/observe_main.py", line 327, in __enter__
    noisediode.off(self.array)
  File "/usr/local/lib/python3.8/dist-packages/astrokat/noisediode.py", line 259, in off
    true_timestamp = _switch_on_off_(kat, timestamp)
  File "/usr/local/lib/python3.8/dist-packages/astrokat/noisediode.py", line 186, in _switch_on_off_
    timestamp = _set_dig_nd_(kat,
  File "/usr/local/lib/python3.8/dist-packages/astrokat/noisediode.py", line 72, in _set_dig_nd_
    nd_antennas = sorted(ant.name for ant in kat.ants)
  File "/usr/local/lib/python3.8/dist-packages/astrokat/noisediode.py", line 72, in <genexpr>
    nd_antennas = sorted(ant.name for ant in kat.ants)
RuntimeError: generator raised StopIteration
```

Traced error to outdated implementation
https://www.python.org/dev/peps/pep-0479/
```
Finally, the proposal also clears up the confusion about how to terminate a generator: the proper way is return, not raise StopIteration.
```

These issues were undetected because the highest version I have is Python3.5 and cannot see these issues.