### PR TITLE
Slew instead of 0-second track for first target to help FBFUSE

### DIFF
--- a/astrokat/observe_main.py
+++ b/astrokat/observe_main.py
@@ -151,10 +151,15 @@ def initial_slew(session, target_info):
             raise session.FBFUSEError("Provision beams not ready")
 
     # Wait until a quorum is in position (with timeout)
-    if not session.kat.dry_run:
-        session.wait(session.ants, 'lock', True, timeout=300, quorum=session.quorum)
+    success = session.wait(session.ants,
+                           'lock',
+                           True,
+                           timeout=300,
+                           quorum=session.quorum)
+    if success:
+        user_logger.info('target reached')
+    # session.wait will issue a waring if quorum not reached
 
-    user_logger.info('target reached')
 
 
 def observe(session, target_info, **kwargs):

--- a/astrokat/observe_main.py
+++ b/astrokat/observe_main.py
@@ -146,7 +146,7 @@ def initial_slew(session, target_info):
 
     # Initiate FBFUSE proxy settings from mkat-sessions capture_start
     if session.fbf:
-        user_logger.info('Initiating FBF beam complete')
+        user_logger.info('Waiting for FBF beam complete')
         if not session.fbf.check_provisioning_beams_complete():
             raise session.FBFUSEError("Provision beams not ready")
 

--- a/astrokat/observe_main.py
+++ b/astrokat/observe_main.py
@@ -424,6 +424,21 @@ def run_observation(opts, kat):
     # remove observation specific instructions housed in YAML file
     del opts.obs_plan_params
 
+    # if FBFUSE proxy is available, this observer allows it to block
+    # at startup of observation to allow setup of beams
+    fbf_block_allowed = False
+    if "instrument" in obs_plan_params:
+        instrument_dict = obs_plan_params['instrument']
+        if "partner_resources" in instrument_dict:
+            partners = instrument_dict['partner_resources']
+            if 'fbfuse' in partners:
+                fbf_block_allowed = True
+
+    # RVR test
+    # only for integration tests, remove after test
+    print('FBF block is allowed = {}'.format(fbf_block_allowed))
+    # RVR test
+
     # set up duration periods for observation control
     obs_duration = -1
     if "durations" in obs_plan_params:
@@ -616,6 +631,7 @@ def run_observation(opts, kat):
             print('FBF proxy in array = {}'.format(session.fbf))
             # RVR test
 
+            # if session.fbf and fbf_block_allowed:
             if session.fbf:
                 user_logger.warn('Initiating FBF beam complete block')
                 if not session.fbf.check_provisioning_beams_complete():

--- a/astrokat/observe_main.py
+++ b/astrokat/observe_main.py
@@ -610,6 +610,12 @@ def run_observation(opts, kat):
             # Thus will allow an up to 5 minute wait to all observations
             # that is run on an array with the FBFUSE proxy included in the
             # array
+
+            # RVR test
+            # only for integration tests, remove after test
+            print('FBF proxy in array = {}'.format(session.fbf))
+            # RVR test
+
             if session.fbf:
                 user_logger.warn('Initiating FBF beam complete block')
                 if not session.fbf.check_provisioning_beams_complete():

--- a/astrokat/observe_main.py
+++ b/astrokat/observe_main.py
@@ -610,7 +610,7 @@ def run_observation(opts, kat):
             # Thus will allow an up to 5 minute wait to all observations
             # that is run on an array with the FBFUSE proxy included in the
             # array
-            if session.fbf():
+            if session.fbf:
                 user_logger.warn('Initiating FBF beam complete block')
                 if not session.fbf.check_provisioning_beams_complete():
                     raise session.FBFUSEError("Provision beams not ready")

--- a/astrokat/observe_main.py
+++ b/astrokat/observe_main.py
@@ -137,7 +137,6 @@ def initial_slew(session, target_info):
     user_logger.info("Slewing to target {}".format(target_name))
     session.set_target(katpt_tgt)
     session.activity('slew')
-    # Start moving each antenna to the target
     if session.kat.dry_run:
         # Apply average slew time
         session._slew_to(katpt_tgt)

--- a/astrokat/observe_main.py
+++ b/astrokat/observe_main.py
@@ -606,6 +606,15 @@ def run_observation(opts, kat):
                 "DEBUG: Initialise capture start with timestamp "
                 "{} ({})".format(int(time.time()), timestamp2datetime(time.time()))
             )
+            # Adding the FBF proxy BLOCK command here
+            # Thus will allow an up to 5 minute wait to all observations
+            # that is run on an array with the FBFUSE proxy included in the
+            # array
+            if session.fbf():
+                user_logger.warn('Initiating FBF beam complete block')
+                if not session.fbf.check_provisioning_beams_complete():
+                    raise session.FBFUSEError("Provision beams not ready")
+                user_logger.info('Continue observation')
 
             # Go to first target before starting capture
             user_logger.info("Slewing to first target")

--- a/astrokat/observe_main.py
+++ b/astrokat/observe_main.py
@@ -161,7 +161,6 @@ def initial_slew(session, target_info):
     # session.wait will issue a waring if quorum not reached
 
 
-
 def observe(session, target_info, **kwargs):
     """Target observation functionality.
 

--- a/astrokat/observe_main.py
+++ b/astrokat/observe_main.py
@@ -122,7 +122,7 @@ def read_targets(target_items):
     return target_list
 
 
-def slew(session, target_info):
+def initial_slew(session, target_info):
     """Simple way to get telescope to slew to target
 
     Parameters
@@ -131,9 +131,10 @@ def slew(session, target_info):
     target_info: dictionary with target observation info
 
     """
+    target_name = target_info["name"]
     katpt_tgt = target_info["target"]
 
-    user_logger.info("Slewing to first target")
+    user_logger.info("Slewing to target {}".format(target_name))
     session.set_target(katpt_tgt)
     session.activity('slew')
     # Start moving each antenna to the target
@@ -639,7 +640,7 @@ def run_observation(opts, kat):
             )
 
             # Go to first target before starting capture
-            slew(session, obs_targets[0])
+            initial_slew(session, obs_targets[0])
 
             # Only start capturing once we are on target
             session.capture_start()

--- a/astrokat/observe_main.py
+++ b/astrokat/observe_main.py
@@ -122,6 +122,21 @@ def read_targets(target_items):
     return target_list
 
 
+def slew(session, target):
+    session.activity('slew')
+    user_logger.info('slewing to target')
+    # Start moving each antenna to the target
+    if session.kat.dry_run:
+        session._slew_to(target)
+    else:
+        ants = session.ants
+        # ants = session.kat.ants
+        ants.req.mode('POINT')
+        # Wait until a quorum is in position (with timeout)
+        session.wait(ants, 'lock', True, timeout=300, quorum=session.quorum)
+    user_logger.info('target reached')
+
+
 def observe(session, target_info, **kwargs):
     """Target observation functionality.
 
@@ -140,7 +155,13 @@ def observe(session, target_info, **kwargs):
 
     # simple way to get telescope to slew to target
     if "slewonly" in kwargs:
-        return session.track(target, duration=0.0, announce=False)
+        # RVR test
+        # only for integration tests, remove after test
+        print('Using slew only function')
+        return slew(session, target)
+        # RVR test
+#         print('0 sec track')
+#         return session.track(target, duration=0.0, announce=False)
 
     # set noise diode behaviour
     nd_setup = None

--- a/astrokat/simulate.py
+++ b/astrokat/simulate.py
@@ -160,6 +160,13 @@ class SimSession(object):
         self.time = self.start_time
         self.katpt_current = None
         self.capture_initialised = False
+        # add USE proxy indicators
+        if "instrument" in self.obs_params:
+            instrument_dict = self.obs_params['instrument']
+            if "pool_resources" in instrument_dict:
+                pool_resources = instrument_dict['pool_resources']
+                if 'fbfuse' not in pool_resources:
+                    self.fbf = False
 
         # Taken from mkat_session.py to ensure similar behaviour than site
         # systems

--- a/astrokat/simulate.py
+++ b/astrokat/simulate.py
@@ -202,7 +202,7 @@ class SimSession(object):
 
     def __iter__(self):
         yield self
-        raise StopIteration
+        return
 
     def __exit__(self, type, value, traceback):
         # TODO: self.track_ cleanup for multiple obs loops

--- a/astrokat/simulate.py
+++ b/astrokat/simulate.py
@@ -243,7 +243,8 @@ class SimSession(object):
         self.track_ = True
         slew_time, az, el = self._fake_slew_(target)
         time.sleep(slew_time)
-        user_logger.info("Slewed to %s at azel (%.1f, %.1f) deg", target.name, az, el)
+        if announce:
+            user_logger.info("Slewed to %s at azel (%.1f, %.1f) deg", target.name, az, el)
         time.sleep(duration)
         if duration > 0:
             user_logger.info("Tracked %s for %d seconds", target.name, duration)

--- a/astrokat/simulate.py
+++ b/astrokat/simulate.py
@@ -221,6 +221,14 @@ class SimSession(object):
             user_logger.info('INIT')
             self.capture_initialised = True
 
+    def wait(self, *args, **kwargs):
+        """Simulate sessions wait function"""
+        time.sleep(_DEFAULT_SLEW_TIME_SEC)
+
+    def _slew_to(self, target):
+        """TimeSession replacement for wait"""
+        self.track(target, duration=0.0, announce=False)
+
     def track(self, target, duration=0, announce=False):
         """Simulate the track source functionality during observations.
 
@@ -237,7 +245,8 @@ class SimSession(object):
         time.sleep(slew_time)
         user_logger.info("Slewed to %s at azel (%.1f, %.1f) deg", target.name, az, el)
         time.sleep(duration)
-        user_logger.info("Tracked %s for %d seconds", target.name, duration)
+        if duration > 0:
+            user_logger.info("Tracked %s for %d seconds", target.name, duration)
         return True
 
     def raster_scan(

--- a/astrokat/simulate.py
+++ b/astrokat/simulate.py
@@ -224,6 +224,7 @@ class SimSession(object):
     def wait(self, *args, **kwargs):
         """Simulate sessions wait function"""
         time.sleep(_DEFAULT_SLEW_TIME_SEC)
+        return True
 
     def _slew_to(self, target):
         """TimeSession replacement for wait"""

--- a/astrokat/test/test_nd_timings.py
+++ b/astrokat/test/test_nd_timings.py
@@ -58,7 +58,7 @@ class TestAstrokatYAML(unittest.TestCase):
 
         result = LoggedTelescope.user_logger_stream.getvalue()
         self.assertIn("No ND for target", result)
-        self.assertIn("noise-diode off at 1573714914.0", result)
+        self.assertIn("noise-diode off at 1573714959.0", result)
         self.assertIn("Restoring ND pattern", result)
         self.assertIn("noise diode pattern every 0.1 sec, with 0.05 sec on",
                       result)
@@ -71,8 +71,8 @@ class TestAstrokatYAML(unittest.TestCase):
         result = LoggedTelescope.user_logger_stream.getvalue()
         self.assertIn("Firing noise diode for 15.0s", result)
         self.assertIn("Add lead time of 5.0s", result)
-        self.assertIn("noise-diode on at 1573714853.0", result)
-        self.assertIn("noise-diode off at 1573714868.0", result)
+        self.assertIn("noise-diode on at 1573714898.0", result)
+        self.assertIn("noise-diode off at 1573714913.0", result)
 
     def test_nd_trigger_short(self):
         """Tests noisediode simulator."""
@@ -82,5 +82,5 @@ class TestAstrokatYAML(unittest.TestCase):
         self.assertIn("Firing noise diode for 2.0s", result)
         self.assertIn("Add lead time of 5.0s", result)
         self.assertIn("Set noise diode pattern", result)
-        self.assertIn("noise-diode pattern on at 1573714853.0", result)
-        self.assertIn("noise-diode off at 1573714858.0", result)
+        self.assertIn("noise-diode pattern on at 1573714898.0", result)
+        self.assertIn("noise-diode off at 1573714903.0", result)


### PR DESCRIPTION
`FBFUSE` / MeerTIME observations had some issues with the astrokat observation script when `FBFUSE` ran commensally in the array with a MeerTIME pulsar observation.

Errors and ideas were discussed during a site integration session and it was noticed that astrokat on the "slew to first target" -- lacks the `fbf.check_provisioning_beams_complete` as implemented in `sessions.capture_start`. This allows the FBF setup of the beams

For astrokat the optimal implementation of this missing requirement was to add an explicit *slew* function to replace the current 0 sec duration track that mimicked the slew.
During this slew to first target (which is expected to be the longest slew in general) the FBF beam check is initiated once the antennas are instructed to POINT to target, this should utilise the slew dead time for FBF config