### PR TITLE
Revert "Slew instead of 0-second track for first target to help FBFUSE"

### DIFF
--- a/astrokat/simulate.py
+++ b/astrokat/simulate.py
@@ -160,13 +160,6 @@ class SimSession(object):
         self.time = self.start_time
         self.katpt_current = None
         self.capture_initialised = False
-        # add USE proxy indicators
-        if "instrument" in self.obs_params:
-            instrument_dict = self.obs_params['instrument']
-            if "pool_resources" in instrument_dict:
-                pool_resources = instrument_dict['pool_resources']
-                if 'fbfuse' not in pool_resources:
-                    self.fbf = False
 
         # Taken from mkat_session.py to ensure similar behaviour than site
         # systems
@@ -202,7 +195,7 @@ class SimSession(object):
 
     def __iter__(self):
         yield self
-        return
+        raise StopIteration
 
     def __exit__(self, type, value, traceback):
         # TODO: self.track_ cleanup for multiple obs loops
@@ -221,15 +214,6 @@ class SimSession(object):
             user_logger.info('INIT')
             self.capture_initialised = True
 
-    def wait(self, *args, **kwargs):
-        """Simulate sessions wait function"""
-        time.sleep(_DEFAULT_SLEW_TIME_SEC)
-        return True
-
-    def _slew_to(self, target):
-        """TimeSession replacement for wait"""
-        self.track(target, duration=0.0, announce=False)
-
     def track(self, target, duration=0, announce=False):
         """Simulate the track source functionality during observations.
 
@@ -244,11 +228,9 @@ class SimSession(object):
         self.track_ = True
         slew_time, az, el = self._fake_slew_(target)
         time.sleep(slew_time)
-        if announce:
-            user_logger.info("Slewed to %s at azel (%.1f, %.1f) deg", target.name, az, el)
+        user_logger.info("Slewed to %s at azel (%.1f, %.1f) deg", target.name, az, el)
         time.sleep(duration)
-        if duration > 0:
-            user_logger.info("Tracked %s for %d seconds", target.name, duration)
+        user_logger.info("Tracked %s for %d seconds", target.name, duration)
         return True
 
     def raster_scan(

--- a/astrokat/test/test_nd_timings.py
+++ b/astrokat/test/test_nd_timings.py
@@ -58,7 +58,7 @@ class TestAstrokatYAML(unittest.TestCase):
 
         result = LoggedTelescope.user_logger_stream.getvalue()
         self.assertIn("No ND for target", result)
-        self.assertIn("noise-diode off at 1573714959.0", result)
+        self.assertIn("noise-diode off at 1573714914.0", result)
         self.assertIn("Restoring ND pattern", result)
         self.assertIn("noise diode pattern every 0.1 sec, with 0.05 sec on",
                       result)
@@ -71,8 +71,8 @@ class TestAstrokatYAML(unittest.TestCase):
         result = LoggedTelescope.user_logger_stream.getvalue()
         self.assertIn("Firing noise diode for 15.0s", result)
         self.assertIn("Add lead time of 5.0s", result)
-        self.assertIn("noise-diode on at 1573714898.0", result)
-        self.assertIn("noise-diode off at 1573714913.0", result)
+        self.assertIn("noise-diode on at 1573714853.0", result)
+        self.assertIn("noise-diode off at 1573714868.0", result)
 
     def test_nd_trigger_short(self):
         """Tests noisediode simulator."""
@@ -82,5 +82,5 @@ class TestAstrokatYAML(unittest.TestCase):
         self.assertIn("Firing noise diode for 2.0s", result)
         self.assertIn("Add lead time of 5.0s", result)
         self.assertIn("Set noise diode pattern", result)
-        self.assertIn("noise-diode pattern on at 1573714898.0", result)
-        self.assertIn("noise-diode off at 1573714903.0", result)
+        self.assertIn("noise-diode pattern on at 1573714853.0", result)
+        self.assertIn("noise-diode off at 1573714858.0", result)


### PR DESCRIPTION
Reverts ska-sa/astrokat#92

For details see issue #93

As we want to do a new CAM release, we need CAM AQF tests to pass, so reverting the change in the meantime.
