### PR TITLE
OPS-1899: Increase noise diode lead time and handle errors better

### DIFF
--- a/astrokat/__init__.py
+++ b/astrokat/__init__.py
@@ -2,16 +2,6 @@
 from __future__ import division
 from __future__ import absolute_import
 
-# Constants and defaults
-_DEFAULT_LEAD_TIME = 5.0  # lead time [sec]
-def max_cycle_len(band):
-    if band.lower() == 'u':
-        return 31.  # buffer len [sec]
-    else:
-        # default is L-band
-        return 20.  # buffer len [sec]
-# Constants and defaults
-
 from .__main__ import cli
 
 from . import noisediode

--- a/astrokat/__init__.py
+++ b/astrokat/__init__.py
@@ -3,7 +3,7 @@ from __future__ import division
 from __future__ import absolute_import
 
 # Constants and defaults
-_DEFAULT_LEAD_TIME = 3.0  # lead time [sec]
+_DEFAULT_LEAD_TIME = 5.0  # lead time [sec]
 def max_cycle_len(band):
     if band.lower() == 'u':
         return 31.  # buffer len [sec]

--- a/astrokat/noisediode.py
+++ b/astrokat/noisediode.py
@@ -2,8 +2,10 @@
 from __future__ import division
 from __future__ import absolute_import
 
-import numpy as np
 import time
+
+import katpoint
+import numpy as np
 
 try:
     from katcorelib import user_logger
@@ -92,11 +94,11 @@ def _set_dig_nd_(kat,
         # The digitiser master controller takes about 15-50 ms per request,
         # so start panicking just before the deadline.
         if time.time() > timestamp - 0.02:
-            user_logger.error('Requested noise diode timestamp %s will probably '
+            user_logger.error('Requested noise diode timestamp %sZ will probably '
                               'be in the past - please increase lead time',
-                              time.ctime(timestamp))
-            skipped = ', '.join(nd_antennas[len(replies):])
-            user_logger.error('Skipped setting noise diodes on: %s', skipped)
+                              katpoint.Timestamp(timestamp))
+            skipped = ','.join(nd_antennas[len(replies):])
+            user_logger.error('Skipped setting these noise diodes: %s', skipped)
             break
         replies[ant] = ped.req.dig_noise_source(timestamp,
                                                 on_fraction,
@@ -117,9 +119,9 @@ def _set_dig_nd_(kat,
         if len(replies) < len(nd_antennas):
             user_logger.error('Noise diode activation not in sync')
     if np.isfinite(timestamp):
-        msg = ('Set successful noise diodes with average timestamp {:.0f} ({})'
+        msg = ('Set successful noise diodes with average timestamp {:.0f} ({}Z)'
                .format(timestamp,
-                       time.ctime(timestamp)))
+                       katpoint.Timestamp(timestamp)))
         user_logger.debug('DEBUG: {}'.format(msg))
 
     return timestamp

--- a/astrokat/noisediode.py
+++ b/astrokat/noisediode.py
@@ -132,13 +132,12 @@ def _katcp_reply_(dig_katcp_replies):
     ant_ts_list = []
     for ant in sorted(dig_katcp_replies):
         reply, informs = dig_katcp_replies[ant]
-        if reply.reply_ok():
+        if reply.succeeded:
             ant_ts_list.append(_nd_log_msg_(ant, reply, informs))
         else:
-            msg = 'Unexpected noise diode reply from ant {}'.format(ant)
+            msg = ('Noise diode request failed on ant {}: {} ({})'
+                   .format(ant, reply.arguments, informs))
             user_logger.warn(msg)
-            user_logger.debug('DEBUG: {}'.format(reply.arguments))
-            continue
     # assume all ND timestamps similar and return average
     return np.mean(ant_ts_list) if ant_ts_list else np.nan
 

--- a/astrokat/noisediode.py
+++ b/astrokat/noisediode.py
@@ -118,8 +118,8 @@ def _set_dig_nd_(kat,
             user_logger.error('Noise diode activation not in sync')
     if np.isfinite(timestamp):
         msg = ('Set successful noise diodes with average timestamp {:.0f} ({})'
-            .format(timestamp,
-                    time.ctime(timestamp)))
+               .format(timestamp,
+                       time.ctime(timestamp)))
         user_logger.debug('DEBUG: {}'.format(msg))
 
     return timestamp

--- a/astrokat/noisediode.py
+++ b/astrokat/noisediode.py
@@ -13,22 +13,23 @@ except ImportError:
 
 # Constants and defaults
 _DEFAULT_LEAD_TIME = 5.0  # lead time [sec]
-def max_cycle_len(band):
+
+
+def max_cycle_len_per_band(band):
     if band.lower() == 'u':
         return 31.  # buffer len [sec]
     else:
         # default is L-band
         return 20.  # buffer len [sec]
-# Constants and defaults
 
 
 def _get_max_cycle_len(kat):
     """Get maximum cycle length for noise diode switching
     """
     if not kat.dry_run:
-        return max_cycle_len(kat.sensor.sub_band.get_value())
+        return max_cycle_len_per_band(kat.sensor.sub_band.get_value())
     else:
-        return max_cycle_len('l')
+        return max_cycle_len_per_band('l')
 
 
 def _get_nd_timestamp_(lead_time):

--- a/astrokat/noisediode.py
+++ b/astrokat/noisediode.py
@@ -9,8 +9,17 @@ try:
     from katcorelib import user_logger
 except ImportError:
     from .simulate import user_logger
-from . import _DEFAULT_LEAD_TIME
-from . import max_cycle_len
+
+
+# Constants and defaults
+_DEFAULT_LEAD_TIME = 5.0  # lead time [sec]
+def max_cycle_len(band):
+    if band.lower() == 'u':
+        return 31.  # buffer len [sec]
+    else:
+        # default is L-band
+        return 20.  # buffer len [sec]
+# Constants and defaults
 
 
 def _get_max_cycle_len(kat):
@@ -25,6 +34,8 @@ def _get_max_cycle_len(kat):
 def _get_nd_timestamp_(lead_time):
     """Timestamp for ND switch command with lead time
     """
+    if lead_time is None:
+        lead_time = _DEFAULT_LEAD_TIME
     return time.time() + lead_time
 
 
@@ -193,7 +204,7 @@ def _switch_on_off_(kat,
 # switch noise-source on
 def on(kat,
        timestamp=None,
-       lead_time=_DEFAULT_LEAD_TIME):
+       lead_time=None):
     """Switch noise-source pattern on.
 
     Parameters
@@ -235,7 +246,7 @@ def on(kat,
 # switch noise-source pattern off
 def off(kat,
         timestamp=None,
-        lead_time=_DEFAULT_LEAD_TIME):
+        lead_time=None):
     """Switch noise-source pattern off.
 
     Parameters
@@ -266,7 +277,7 @@ def off(kat,
 # fire noise diode before track
 def trigger(kat,
             duration=None,
-            lead_time=_DEFAULT_LEAD_TIME):
+            lead_time=None):
     """Fire the noise diode before track.
 
     Parameters
@@ -281,6 +292,8 @@ def trigger(kat,
 
     if duration is None:
         return True  # nothing to do
+    if lead_time is None:
+        lead_time = _DEFAULT_LEAD_TIME
 
     msg = ('Firing noise diode for {}s before target observation'
            .format(duration))
@@ -349,7 +362,7 @@ def trigger(kat,
 # set noise diode pattern
 def pattern(kat,
             nd_setup,
-            lead_time=_DEFAULT_LEAD_TIME,
+            lead_time=None,
             ):
     """Start background noise diode pattern controlled by digitiser hardware.
 
@@ -371,6 +384,8 @@ def pattern(kat,
     timestamp : float
         Linux timestamp reported by digitiser
     """
+    if lead_time is None:
+        lead_time = _DEFAULT_LEAD_TIME
 
     # nd pattern length [sec]
     max_cycle_len = _get_max_cycle_len(kat)

--- a/astrokat/observe_main.py
+++ b/astrokat/observe_main.py
@@ -9,7 +9,6 @@ import time
 import astrokat
 from astrokat.utility import datetime2timestamp, timestamp2datetime
 from astrokat import (
-    _DEFAULT_LEAD_TIME,
     NoTargetsUpError,
     NotAllTargetsUpError,
     get_lst,
@@ -144,7 +143,7 @@ def observe(session, target_info, **kwargs):
 
     # set noise diode behaviour
     nd_setup = None
-    nd_lead = _DEFAULT_LEAD_TIME
+    nd_lead = None
     if kwargs.get("noise_diode"):
         nd_setup = kwargs["noise_diode"]
         # user specified lead time
@@ -567,9 +566,7 @@ def run_observation(opts, kat):
             #  so it happens in the line above
             if "noise_diode" in obs_plan_params:
                 nd_setup = obs_plan_params["noise_diode"]
-                nd_lead = _DEFAULT_LEAD_TIME
-                if "lead_time" in nd_setup:
-                    nd_lead = nd_setup['lead_time']
+                nd_lead = nd_setup.get('lead_time')
 
                 # Set noise diode period to multiple of correlator integration time.
                 if not kat.array.dry_run:

--- a/astrokat/observe_main.py
+++ b/astrokat/observe_main.py
@@ -340,7 +340,8 @@ class Telescope(object):
         # Ensure known exit state before quitting
         # TODO: Return correlator settings to entry values
         # switch noise-source pattern off (ensure this after each observation)
-        noisediode.off(self.array)
+        # if NaN returned at off command, allow to continue
+        noisediode.off(self.array, allow_ts_err=True)
         self.array.disconnect()
 
     def subarray_setup(self, instrument):

--- a/astrokat/test/test_nd/nd-pattern-plus-off.yaml
+++ b/astrokat/test/test_nd/nd-pattern-plus-off.yaml
@@ -3,6 +3,7 @@ noise_diode:
   antennas: all
   cycle_len: 0.1  # 100ms
   on_frac: 0.5  # 50%
+  lead_time: 3.  # sec
 durations:
   start_time: 2019-11-14 07:00:00
   obs_duration: 300


### PR DESCRIPTION
Turning off 63 L-band noise diodes on 2021-04-15 took about 3.3 seconds, much longer than the usual 1.0 - 1.5 seconds. This caused the final few KATCP requests to fail and the script to crash.

The culprit is the increased number of S-band digitisers being serviced by the digitiser master controller, so this situation may persist in the near future. For now, increase the lead time from 3.0 to 5.0 seconds.

Do some refactoring of the lead time constant and `max_cycle_len` function. These seem to be used exclusively inside the `noisediode` module within `astrokat`. Please advise if external user scripts expect them at the top level of the package.

Improve the error handling when the lead time is too short. Check if we ran out of time and skip the rest of the noise diodes while reporting the error. We have other options here too:
   - Crash.
   - Retry the operation with a longer lead time based on how long it took thus far.

Crashing is a bit harsh for the extremely common scenario of just switching the noise diodes off. If the lead time is still too short, the operator could go and switch off noise diodes manually and the `astrokat-observe` script would then complain but continue. The alternative would involve either another hotfix or YAML hacking.

Refuse to handle an invalid timestamp to avoid crashes. There are options here too:
  - Don't bother reporting the average timestamp at the end of `_set_dig_nd_`. If you have `cycle=True`, the average won't make that much sense, and for the simulator it will be the final timestamp instead of the average anyway (i.e. it's a mess).
  - Don't return the timestamp from noise diode functions since they are ignored by the highest-level functionality. This way you can avoid spreading an invalid or hard-to-interpret timestamp.
 