### PR TITLE
OPS-1899: Fix KATCP request check for success

### DIFF
--- a/astrokat/noisediode.py
+++ b/astrokat/noisediode.py
@@ -132,7 +132,7 @@ def _katcp_reply_(dig_katcp_replies):
     ant_ts_list = []
     for ant in sorted(dig_katcp_replies):
         reply, informs = dig_katcp_replies[ant]
-        if reply.succeeded:
+        if reply.reply_ok():
             ant_ts_list.append(_nd_log_msg_(ant, reply, informs))
         else:
             msg = ('Noise diode request failed on ant {}: {} ({})'


### PR DESCRIPTION
I inadvertently switched to the `katcorelib` KATCP client style of checking success (used in CaptureSession), not realising that this uses raw KATCP.

Is there a way to test this on a real katcorelib to know that all is well before deployment?