### PR TITLE
Pin `coverage` to the latest version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ commands =
     coverage html
     coverage report -m --skip-covered
 deps =
-    coverage<5.0.0  # see https://github.com/nedbat/coveragepy/issues/716
+    coverage==5.5
     mock
     nose
     nosexcover


### PR DESCRIPTION
This PR does the following:
- Pins the version of `coverage` to a more stable version that supports both Python2 and Python3

Hopefully, this fixes these [build failures](http://ci.camlab.kat.ac.za/job/astrokat-multibranch/job/master/)
![image](https://user-images.githubusercontent.com/7910856/119360059-882c5100-bcaa-11eb-9993-e0b334e7d088.png)
