### PR TITLE
Support pyephem 4.0 time parser

### DIFF
--- a/astrokat/test/test_offline_observe.py
+++ b/astrokat/test/test_offline_observe.py
@@ -3,10 +3,17 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import unittest
+import katpoint
 
 from mock import patch
 
-from .testutils import LoggedTelescope, execute_observe_main
+from astrokat import utility
+from .testutils import (
+    LoggedTelescope,
+    execute_observe_main,
+    extract_start_time,
+    yaml_path,
+)
 
 
 @patch("astrokat.observe_main.Telescope", LoggedTelescope)
@@ -162,3 +169,40 @@ class TestAstrokatYAML(unittest.TestCase):
         self.assertIn(
             expected_results, result, "J1833-2103 skipped"
         )
+
+    def test_time_conversion_symmetry(self):
+        """Test katpoint and astrokat time conversion methods match and are symmetrical"""
+        test_files = [
+            "test_obs/below-horizon-sim.yaml",
+            "test_obs/image-cals-sim.yaml",
+            "test_obs/image-sim.yaml",
+            "test_obs/image-single-sim.yaml",
+            "test_obs/targets-sim.yaml",
+            "test_obs/two-calib-sim.yaml",
+        ]
+        for test_file in test_files:
+            file_path = yaml_path(test_file)
+            yaml_start_time = extract_start_time(file_path)
+            yaml_start_time_str = str(yaml_start_time)
+
+            astrokat_sec_since_epoch = utility.datetime2timestamp(yaml_start_time)
+            katpoint_sec_since_epoch = katpoint.Timestamp(yaml_start_time_str).secs
+            self.assertAlmostEqual(
+                astrokat_sec_since_epoch,
+                katpoint_sec_since_epoch,
+                places=6,
+                msg="timestamp conversion mismatch {}".format(test_file)
+            )
+
+            astrokat_datetime = utility.timestamp2datetime(astrokat_sec_since_epoch)
+            katpoint_timestamp = katpoint.Timestamp(katpoint_sec_since_epoch)
+            self.assertEqual(
+                str(astrokat_datetime),
+                yaml_start_time_str,
+                msg="astrokat str time conversion mismatch for {}".format(test_file)
+            )
+            self.assertEqual(
+                str(katpoint_timestamp),
+                yaml_start_time_str,
+                msg="katpoint str time conversion mismatch for {}".format(test_file)
+            )

--- a/astrokat/utility.py
+++ b/astrokat/utility.py
@@ -52,9 +52,12 @@ def read_yaml(filename):
         if "start_time" in data["durations"]:
             start_time = data["durations"]["start_time"]
             if isinstance(start_time, str):
-                data["durations"]["start_time"] = datetime.datetime.strptime(
+                start_time = datetime.datetime.strptime(
                     start_time, "%Y-%m-%d %H:%M"
                 )
+            elif isinstance(start_time, datetime.datetime):
+                start_time = start_time.replace(tzinfo=None)
+            data["durations"]["start_time"] = start_time
     if "observation_loop" not in data.keys():
         raise RuntimeError("Nothing to observe, exiting")
     if data["observation_loop"] is None:
@@ -91,7 +94,7 @@ def datetime2timestamp(datetime_obj):
 
     """
     epoch = datetime.datetime.utcfromtimestamp(0)
-    return (datetime_obj.replace(tzinfo=None) - epoch).total_seconds()
+    return (datetime_obj - epoch).total_seconds()
 
 
 def timestamp2datetime(timestamp):


### PR DESCRIPTION
Remove timezone info from `start_time` after loading from YAML.  If times have a trailing "Z", then the string representations are like 2019-02-11 02:10:47+00:00.  ephem <= 3.7.7.1 was OK to parse that (and ignored the timezone suffix).  Since version 4.0.0.1, the ephem parser is stricter and complains about these times.

This problem wasn't seen in the astrokat unit tests for this repo, but was picked up in the CAM AQF tests.  CAM AQF use katcorelib, instead of the simulated session.  The difference in katcorelib is that the start time is converted via `katpoint.Timestamp`, instead of `astrokat.datetime2timestamp`.

Added a unit test to ensure the conversions between astrokat and katpoint are equivalent, and exercise the ephem converter.

See more details [here](https://github.com/ska-sa/astrokat/pull/102/files#r651602048).