### PR TITLE
Support katcorelib in drift scan tests

### DIFF
--- a/astrokat/test/test_scans.py
+++ b/astrokat/test/test_scans.py
@@ -29,10 +29,9 @@ class TestAstrokatYAML(unittest.TestCase):
         result = LoggedTelescope.user_logger_stream.getvalue()
         self.assertIn("Initialising Drift_scan target 1934-638 for 180.0 sec", result)
         self.assertIn("Drift_scan observation for 180.0 sec", result)
-        self.assertIn("Slewed to Az: -172:57:37.1 El: 56:27:26.4 at azel "
-                      "(-173.0, 56.5) deg",
-                      result)
-        self.assertIn("Tracked Az: -172:57:37.1 El: 56:27:26.4 for 180 seconds", result)
+        target_string = "Az: -172:57:37.1 El: 56:27:26.4"
+        self.assert_started_target_track(target_string, 180.0, result)
+        self.assert_completed_target_track(target_string, 180.0, result)
 
     def test_raster_scan_basic_sim(self):
         """Not much to do: check scan initiate log msg"""
@@ -49,3 +48,26 @@ class TestAstrokatYAML(unittest.TestCase):
         result = LoggedTelescope.user_logger_stream.getvalue()
         self.assertIn("Initialising Scan target scan_1934-638 for 30.0 sec", result)
         self.assertIn("scan_1934-638 observed for 60.0 sec", result)
+
+    def assert_started_target_track(self, target_string, duration, result):
+        simulate_message = "Slewed to {} at azel".format(target_string)
+        katcorelib_message = "Initiating {:g}-second track on target {!r}".format(
+            duration, target_string)
+        simulated_message_found = simulate_message in result
+        katcorelib_message_found = katcorelib_message in result
+        self.assertTrue(
+            simulated_message_found or katcorelib_message_found,
+            "Neither simulate {!r} nor katcorelib {!r} message found.".format(
+                simulate_message, katcorelib_message)
+        )
+
+    def assert_completed_target_track(self, target_string, duration, result):
+        simulate_message = "Tracked {} for {:g} seconds".format(target_string, duration)
+        katcorelib_message = "target tracked for {:g} seconds".format(duration)
+        simulated_message_found = simulate_message in result
+        katcorelib_message_found = katcorelib_message in result
+        self.assertTrue(
+            simulated_message_found or katcorelib_message_found,
+            "Neither simulate {!r} nor katcorelib {!r} message found.".format(
+                simulate_message, katcorelib_message)
+        )


### PR DESCRIPTION
The observation output messages differ between astrokat's [simulate](https://github.com/ska-sa/astrokat/blob/203e5f55797212029cdc87bbbee86f71764f6aa2/astrokat/simulate.py#L231-L233) module and katcorelib's [mkat_session](https://github.com/ska-sa/katcorelib/blob/c4f8e083a8afa26322a099f65d026f08a2255342/katcorelib/mkat_session.py#L1089-L1116) module.  The tests were only considering the messages generated by the simulate module.  Now we also check for messages in the format that katcorelib creates them.

This is to get CAM's AQF test run of astrokat's unit tests to pass:
```
======================================================================
FAIL: Check (az, el) target from (ra, dec) for drift scan
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/mock/mock.py", line 1330, in patched
    return func(*args, **keywargs)
  File "/home/kat/svn/astrokat/astrokat/test/test_scans.py", line 34, in test_drift_scan_basic_sim
    result)
AssertionError: 'Slewed to Az: -172:57:37.1 El: 56:27:26.4 at azel (-173.0, 56.5) deg' not found in "2021-06-24 19:11:25Z - Observation start up\n2021-06-24 19:11:25Z - Running astrokat version - 0.1.dev739+master.203e5f5\n2021-06-24 19:11:25Z - Skipping instrument checks - 20210624-0150 not in approved_schedule\n2021-06-24 19:11:25Z - 
```