### PR TITLE
Hotfix V28: Add "reverse scan" over RADEC area (intensity mapping)

### DIFF
--- a/astrokat/scans.py
+++ b/astrokat/scans.py
@@ -2,16 +2,24 @@
 from __future__ import division
 from __future__ import absolute_import
 
+import copy
+import time
+
 import katpoint
+import numpy as np
 
 from .noisediode import trigger
-
-import time
 
 try:
     from katcorelib import user_logger
 except ImportError:
     from .simulate import user_logger
+
+
+_MIN_HORIZON_EL_FOR_SCAN_DEG = 15.0
+_HORIZON_ANGLE_OFFSET_DEG = 2.0
+_MAX_POINTS_IN_SCAN_AREA_POLYGON = 10
+_DEFAULT_SCAN_SPEED_ARCMIN_PER_SEC = 5.0
 
 
 def drift_pointing_offset(target, duration=60.0):
@@ -131,10 +139,70 @@ def forwardscan(session, target, nd_period=None, lead_time=None, **kwargs):
     return target_visible
 
 
+def _get_scan_area_extents(target_list, antenna_, obs_start_ts, offset_deg=0.1):
+    """Return the elevation, azimuth extents, and time extents of the scan."""
+    antenna = copy.copy(antenna_)
+    antenna.observer.date = obs_start_ts
+    is_rising_list = []
+    el_list = []
+    az_list = []
+    time_list = []
+    for target in target_list:
+        _, el = target.azel(timestamp=obs_start_ts)
+        el_list.append(el)
+        if el < 0:
+            user_logger.warning(
+                target.name + "is below the horizon (%s deg at %s)", el, obs_start_ts
+            )
+    user_logger.debug('Min elevation of scan area at start: %s', min(el_list))
+    user_logger.debug('Max elevation of scan area at start: %s', max(el_list))
+
+    el_just_below_lowest = min(el_list) - np.radians(_HORIZON_ANGLE_OFFSET_DEG)
+    antenna.observer.horizon = el_just_below_lowest
+    for target in target_list:
+        next_transit = antenna.observer.next_transit(target.body)
+        next_setting = antenna.observer.next_setting(target.body)
+        next_rising = antenna.observer.next_rising(target.body)
+        is_rising = next_transit < next_setting < next_rising
+        is_rising_list.append(is_rising)
+        user_logger.debug("Is Target rising :%s, %s" % (target.body, is_rising))
+
+    if all(is_rising_list):
+        # Rising sources
+        antenna.observer.horizon = max(el_list) + np.radians(offset_deg)  # top point
+        user_logger.debug('Highest elevation for rising source: %s', max(el_list))
+        for target in target_list:
+            antenna.observer.next_rising(target.body)  # rise through the scan line
+            az_list.append(target.body.rise_az)
+            time_list.append(target.body.rise_time)
+    else:
+        antenna.observer.horizon = min(el_list) - np.radians(offset_deg)  # bottom point
+        user_logger.debug('Lowest elevation for setting source: %s', min(el_list))
+        for target in target_list:
+            antenna.observer.next_setting(target.body)  # Set through the scan line
+            az_list.append(target.body.set_az)
+            time_list.append(target.body.set_time)
+    min_time = katpoint.Timestamp(min(time_list))
+    max_time = katpoint.Timestamp(max(time_list))
+    user_logger.debug(
+        "Scan Area Points: el: %s, az: %s %s, time: %s %s",
+        antenna.observer.horizon,
+        min(az_list), max(az_list),
+        min_time, max_time,
+    )
+    return (
+        antenna.observer.horizon,
+        min(az_list), max(az_list),
+        min_time, max_time,
+    )
+
+
 def reversescan(session, target, nd_period=None, lead_time=None, **kwargs):
     """Reverse scan observation.
 
-    Call to `scan` method described in this module
+    This scan is done in "Reverse"
+    This means that it is given an area to scan (via kwargs)
+    rather that a target and parameters
 
     Parameters
     ----------
@@ -146,15 +214,108 @@ def reversescan(session, target, nd_period=None, lead_time=None, **kwargs):
         noisediode trigger lead time
 
     """
-    returnscan = dict(kwargs)
-    returnscan["start"] = kwargs["end"]
-    returnscan["end"] = kwargs["start"]
-    target_visible = scan(session,
-                          target,
-                          nd_period=nd_period,
-                          lead_time=lead_time,
-                          **returnscan)
-    return target_visible
+    # trigger noise diode if set
+    trigger(session.kat, duration=nd_period, lead_time=lead_time)
+    if 'radec_p1' in kwargs and 'radec_p2' in kwargs:
+        # means that there is a target area
+        # find lowest setting part or
+        # highest rising part
+        antenna = copy.copy(target.antenna)
+        target_list = []
+        for i in range(1, _MAX_POINTS_IN_SCAN_AREA_POLYGON + 1):
+            key = 'radec_p%i' % i
+            if key in kwargs:
+                target_list.append(
+                    katpoint.Target(
+                        't%i,radec,%s' % (i, kwargs[key]),
+                        antenna=target.antenna,
+                    )
+                )
+    else:
+        user_logger.error("No scan area defined - require radec_p1 and radec_p2")
+        return False
+    direction = kwargs.get("direction", False)
+    scan_speed = kwargs.get("scan_speed", _DEFAULT_SCAN_SPEED_ARCMIN_PER_SEC)
+
+    obs_start_ts = katpoint.Timestamp(time.time()).to_ephem_date()
+    # use 1 deg offset to pre-position >4 min in the future to take into account slewing
+    el, az_min, az_max, t_start, t_end = _get_scan_area_extents(target_list, antenna,
+                                                                obs_start_ts,
+                                                                offset_deg=1)
+
+    # TODO: get horizon limit from observation - may want to pass limits of
+    #       the "acceptable elevation extent" into _get_scan_area_extents.
+    if _MIN_HORIZON_EL_FOR_SCAN_DEG > np.degrees(el):
+        user_logger.warning(
+            "Source and scan below horizon: %s < %s",
+            np.degrees(el),
+            _MIN_HORIZON_EL_FOR_SCAN_DEG,
+        )
+        return False
+
+    scan_target = katpoint.construct_azel_target(katpoint.wrap_angle(az_min), el)
+    scan_target.name = target.name
+    # katpoint destructively set dates and times during calculation
+    # restore datetime before continuing
+    scan_target.antenna = antenna
+    scan_target.antenna.observer.date = obs_start_ts
+    user_logger.info("Slew to scan start")  # slew to target.
+    target_visible = session.track(scan_target, duration=0.0, announce=False)
+    if not target_visible:
+        user_logger.warning(
+            "Start of scan is not visible!  Elevation: %.1f deg.", np.degrees(el)
+        )
+        return False
+
+    # This is the real scan
+    obs_start_ts = katpoint.Timestamp(time.time()).to_ephem_date()
+    el, az_min, az_max, t_start, t_end = _get_scan_area_extents(target_list, antenna,
+                                                                obs_start_ts)
+    scan_target = katpoint.construct_azel_target(
+        katpoint.wrap_angle((az_min + az_max) / 2.), el)
+    scan_target.name = target.name
+    # katpoint destructively set dates and times during calculation
+    # restore datetime before continuing
+    scan_target.antenna = antenna
+    scan_target.antenna.observer.date = obs_start_ts
+
+    scan_start = np.degrees(az_min - (az_min + az_max) / 2.)
+    scan_end = np.degrees(az_max - (az_min + az_max) / 2.)
+
+    scanargs = {}
+    if "projection" in kwargs:
+        scanargs["projection"] = kwargs["projection"]
+
+    # take into account projection effects of the sky and convert to degrees per second
+    # E.g., 5 arcmin/s should translate to 5/60/cos(el) deg/s
+    scan_speed = (scan_speed / 60.0) / np.cos(el)
+    scanargs["duration"] = abs(scan_start - scan_end) / scan_speed  # Duration in seconds
+    user_logger.info(
+        "Scan duration is %.2f and scan speed is %.2f deg/s",
+        scanargs["duration"], scan_speed
+    )
+    user_logger.info("Start Time: %s", t_start)
+    user_logger.info("End Time: %s", t_end)
+    num_scan_lines = 0
+    while time.time() <= t_end.secs:
+        if direction:
+            scanargs["start"] = scan_start, 0.0
+            scanargs["end"] = scan_end, 0.0
+        else:
+            scanargs["start"] = scan_end, 0.0
+            scanargs["end"] = scan_start, 0.0
+        user_logger.info("Azimuth scan extent [%.1f, %.1f]" %
+                         (scanargs["start"][0], scanargs["end"][0]))
+        target_visible = scan(session,
+                              scan_target,
+                              nd_period=nd_period,
+                              lead_time=lead_time,
+                              **scanargs)
+        direction = not direction
+        if target_visible:
+            num_scan_lines += 1
+    user_logger.info("Scan completed - %s scan lines", num_scan_lines)
+    return num_scan_lines > 0
 
 
 def return_scan(session, target, nd_period=None, lead_time=None, **kwargs):
@@ -174,18 +335,21 @@ def return_scan(session, target, nd_period=None, lead_time=None, **kwargs):
     """
     # set up 2way scan
     user_logger.info("Forward scan over target")
-    target_visible = forwardscan(session,
-                                 target,
-                                 nd_period=nd_period,
-                                 lead_time=lead_time,
-                                 **kwargs)
+    target_visible = scan(session,
+                          target,
+                          nd_period=nd_period,
+                          lead_time=lead_time,
+                          **kwargs)
 
     user_logger.info("Reverse scan over target")
-    target_visible += reversescan(session,
-                                  target,
-                                  nd_period=nd_period,
-                                  lead_time=lead_time,
-                                  **kwargs)
+    returnscan = dict(kwargs)
+    returnscan["start"] = kwargs["end"]
+    returnscan["end"] = kwargs["start"]
+    target_visible &= scan(session,
+                           target,
+                           nd_period=nd_period,
+                           lead_time=lead_time,
+                           **returnscan)
     return target_visible
 
 

--- a/astrokat/simulate.py
+++ b/astrokat/simulate.py
@@ -289,6 +289,9 @@ class SimSession(object):
         announce:
 
         """
+        slew_time, az, el = self._fake_slew_(target)
+        time.sleep(slew_time)
+        user_logger.info("Slewed to %s at azel (%.1f, %.1f) deg", target.name, az, el)
         time.sleep(duration)
         return True
 

--- a/astrokat/test/test_scans.py
+++ b/astrokat/test/test_scans.py
@@ -4,10 +4,12 @@ from __future__ import print_function
 
 import unittest
 
+import katpoint
+
 from mock import patch
 
+from astrokat import scans
 from .testutils import LoggedTelescope, execute_observe_main
-
 
 @patch("astrokat.observe_main.Telescope", LoggedTelescope)
 class TestAstrokatYAML(unittest.TestCase):
@@ -48,6 +50,53 @@ class TestAstrokatYAML(unittest.TestCase):
         result = LoggedTelescope.user_logger_stream.getvalue()
         self.assertIn("Initialising Scan target scan_1934-638 for 30.0 sec", result)
         self.assertIn("scan_1934-638 observed for 60.0 sec", result)
+
+    def test_get_scan_area_extents_for_setting_target(self):
+        """Test of function get_scan_area_extents with setting target."""
+        test_date = katpoint.Timestamp('2010/12/05 02:00:00').to_ephem_date()
+        el, az_min, az_max, t_start, t_end = self.get_scan_area_extents(test_date)
+        self.assertAlmostEqual(el, 0.82988305)  # In radians
+        self.assertAlmostEqual(az_min, 3.67187738)  # In radians
+        self.assertAlmostEqual(az_max, 4.015025139)  # In radians
+        self.assertEqual(int(t_start.secs), 1291514447)
+        self.assertEqual(int(t_end.secs), 1291522147)
+
+    def test_get_scan_area_extents_for_rising_target(self):
+        """Test of function get_scan_area_extents with rising target."""
+        test_date = katpoint.Timestamp('2010/12/05 20:00:00').to_ephem_date()
+        el, az_min, az_max, t_start, t_end = self.get_scan_area_extents(test_date)
+        self.assertAlmostEqual(el, 0.39849024)  # In radians
+        self.assertAlmostEqual(az_min, 2.06043911)  # In radians
+        self.assertAlmostEqual(az_max, 2.25462604)  # In radians
+        self.assertEqual(int(t_start.secs), 1291579227)
+        self.assertEqual(int(t_end.secs), 1291585208)
+
+    def get_scan_area_extents(self, test_date):
+        # Test Antenna: 0-m dish at lat 0:00:00.0, long 0:00:00.0, alt 0.0 m
+        antenna = katpoint.Antenna("Test Antenna", 0, 0, 0)
+        target_list = [
+            katpoint.Target("t1, radec, 05:16:00.0, -25:42:00.0", antenna=antenna),
+            katpoint.Target("t2, radec, 05:16:00.0, -35:36:00.0", antenna=antenna),
+            katpoint.Target("t3, radec, 06:44:00.0, -35:36:00.0", antenna=antenna),
+            katpoint.Target("t4, radec, 06:44:00.0, -25:42:00.0", antenna=antenna),
+        ]
+        el, az_min, az_max, t_start, t_end = scans._get_scan_area_extents(target_list,
+                                                                          antenna,
+                                                                          test_date)
+        return el, az_min, az_max, t_start, t_end
+
+    def test_reverse_scan_basic_sim(self):
+        """Test of reverse scan over an area in the sky."""
+        execute_observe_main("test_scans/reverse-scan-test.yaml")
+        # get result and make sure everything ran properly
+        result = LoggedTelescope.user_logger_stream.getvalue()
+        # Check that calibration tracks can be done
+        self.assertIn("PictorA_r0.5", result)
+        # Check scan details
+        self.assertIn("scan speed is 0.14 deg/s", result)
+        self.assertIn("Azimuth scan extent [-8.3, 8.3]", result)
+        self.assertIn("Scan completed - 48 scan lines", result)
+        self.assertEqual(result.count('Scan target: scan_azel_with_nd_trigger,'), 48)
 
     def assert_started_target_track(self, target_string, duration, result):
         simulate_message = "Slewed to {} at azel".format(target_string)

--- a/astrokat/test/test_scans/reverse-scan-test.yaml
+++ b/astrokat/test/test_scans/reverse-scan-test.yaml
@@ -1,0 +1,41 @@
+# return scan observation with noise diode trigger
+instrument:
+  integration_time: 2
+# set noise diode pattern to fire every 20 seconds and only be on for 0.3s
+noise_diode:
+  antennas: all
+  cycle_len: 20.
+  on_frac: 0.015
+  lead_time: 12.
+
+durations:
+  start_time: 2018-08-11 09:12:00
+
+scan:
+  # achieving a scan speed of 5.0 arcmin/sec
+  scan_speed: 5.0
+  direction: 0
+  radec_p1: 05:16:00.0000, -25:42:00.0000
+  radec_p2: 05:16:00.0000, -35:36:00.0000
+  radec_p3: 06:44:00.0000, -35:36:00.0000
+  radec_p4: 06:44:00.0000, -25:42:00.0000
+  projection: plate-carree
+
+observation_loop:
+  - LST:  00:30-23:30
+    target_list:
+      - name=PictorA_u0.5, radec=5:19:49.721 -45:16:43.7801, tags=target, type=track, duration=70.0
+      - name=PictorA, radec=5:19:49.721 -45:46:43.7801, tags=target, type=track, duration=70.0
+      - name=PictorA_r0.5, radec=5:22:41.7767 -45:46:35.7098, tags=target, type=track, duration=70.0
+      - name=PictorA, radec=5:19:49.721 -45:46:43.7801, tags=target, type=track, duration=70.0
+      - name=PictorA_d0.5, radec=5:19:49.721 -46:16:43.7801, tags=target, type=track, duration=70.0
+      - name=PictorA, radec=5:19:49.721 -45:46:43.7801, tags=target, type=track, duration=70.0
+      - name=PictorA_l0.5, radec=5:16:57.6653 -45:46:35.7098, tags=target, type=track, duration=70.0
+      - name=scan_azel_with_nd_trigger, radec=05:00:00.0 -30:39:00, duration=0, tags=target, type=reversescan
+      - name=PictorA_u0.5, radec=5:19:49.721 -45:16:43.7801, tags=target, type=track, duration=70.0
+      - name=PictorA, radec=5:19:49.721 -45:46:43.7801, tags=target, type=track, duration=70.0
+      - name=PictorA_r0.5, radec=5:22:41.7767 -45:46:35.7098, tags=target, type=track, duration=70.0
+      - name=PictorA, radec=5:19:49.721 -45:46:43.7801, tags=target, type=track, duration=70.0
+      - name=PictorA_d0.5, radec=5:19:49.721 -46:16:43.7801, tags=target, type=track, duration=70.0
+      - name=PictorA, radec=5:19:49.721 -45:46:43.7801, tags=target, type=track, duration=70.0
+      - name=PictorA_l0.5, radec=5:16:57.6653 -45:46:35.7098, tags=target, type=track, duration=70.0

--- a/obs_plans/reversescan.yaml
+++ b/obs_plans/reversescan.yaml
@@ -1,0 +1,38 @@
+# return scan observation with noise diode trigger
+instrument:
+  integration_time: 2
+# set noise diode pattern to fire every 20 seconds and only be on for 0.3s
+noise_diode:
+  antennas: all
+  cycle_len: 20.
+  on_frac: 0.015
+  lead_time: 12.
+
+scan:
+  # achieving a scan speed of 5.0 arcmin/sec
+  scan_speed: 5.0
+  direction: 0
+  radec_p1: 22:16:00.0000, -25:42:00.0000
+  radec_p2: 22:16:00.0000, -35:36:00.0000
+  radec_p3: 23:44:00.0000, -35:36:00.0000
+  radec_p4: 23:44:00.0000, -25:42:00.0000
+  projection: plate-carree
+
+observation_loop:
+  - LST:  00:30-23:30
+    target_list:
+      - name=PictorA_u0.5, radec=5:19:49.721 -45:16:43.7801, tags=target, type=track, duration=70.0
+      - name=PictorA, radec=5:19:49.721 -45:46:43.7801, tags=target, type=track, duration=70.0
+      - name=PictorA_r0.5, radec=5:22:41.7767 -45:46:35.7098, tags=target, type=track, duration=70.0
+      - name=PictorA, radec=5:19:49.721 -45:46:43.7801, tags=target, type=track, duration=70.0
+      - name=PictorA_d0.5, radec=5:19:49.721 -46:16:43.7801, tags=target, type=track, duration=70.0
+      - name=PictorA, radec=5:19:49.721 -45:46:43.7801, tags=target, type=track, duration=70.0
+      - name=PictorA_l0.5, radec=5:16:57.6653 -45:46:35.7098, tags=target, type=track, duration=70.0
+      - name=scan_azel_with_nd_trigger, radec=23:00:00.0 -30:39:00, duration=0, tags=target, type=reversescan
+      - name=PictorA_u0.5, radec=5:19:49.721 -45:16:43.7801, tags=target, type=track, duration=70.0
+      - name=PictorA, radec=5:19:49.721 -45:46:43.7801, tags=target, type=track, duration=70.0
+      - name=PictorA_r0.5, radec=5:22:41.7767 -45:46:35.7098, tags=target, type=track, duration=70.0
+      - name=PictorA, radec=5:19:49.721 -45:46:43.7801, tags=target, type=track, duration=70.0
+      - name=PictorA_d0.5, radec=5:19:49.721 -46:16:43.7801, tags=target, type=track, duration=70.0
+      - name=PictorA, radec=5:19:49.721 -45:46:43.7801, tags=target, type=track, duration=70.0
+      - name=PictorA_l0.5, radec=5:16:57.6653 -45:46:35.7098, tags=target, type=track, duration=70.0


### PR DESCRIPTION
Add "reverse scan" over RADEC area (intensity mapping) to MeerKAT site. For more details, see PR by @spassmoor here - https://github.com/ska-sa/astrokat/pull/106

[JIRA MT-2555] (https://skaafrica.atlassian.net/browse/MT-2555)