### PR TITLE
Hotfix V30: Update astrokat to use new set target functionality

### DIFF
--- a/astrokat/observatory.py
+++ b/astrokat/observatory.py
@@ -151,7 +151,7 @@ class Observatory(object):
         observer.date = ephem.now()
         return observer
 
-    def set_target(self, target):
+    def set_target(self, target, slew_only=False):
         """Set the target.
 
         MeerKAT Wrapper around a PyEphem.Body object, target is an object
@@ -162,7 +162,8 @@ class Observatory(object):
         target: str
             A comma-separated description which contains parameters such as
             the target name, position, flux model.
-
+        slew_only : bool, optional
+            True if only the antenna slews should be performed.
         """
         target = katpoint.Target(target)
         target.body.compute(self.observer)

--- a/astrokat/observe_main.py
+++ b/astrokat/observe_main.py
@@ -76,9 +76,8 @@ def observe(session, ref_antenna, target_info, **kwargs):
 
     Parameters
     ----------
-    session: `CaptureSession`
-    target_info:
-
+    session: `CaptureSession` object
+    target_info: dictionary with target observation info
     """
     target_visible = False
 
@@ -99,7 +98,7 @@ def observe(session, ref_antenna, target_info, **kwargs):
 
     # simple way to get telescope to slew to target
     if "slewonly" in kwargs:
-        return session.track(target, duration=0.0, announce=False)
+        return session.track(target, duration=0.0, announce=False, slew_only=True)
 
     # set noise diode behaviour
     nd_setup = None

--- a/astrokat/simulate.py
+++ b/astrokat/simulate.py
@@ -216,7 +216,7 @@ class SimSession(object):
             user_logger.info('INIT')
             self.capture_initialised = True
 
-    def track(self, target, duration=0, announce=False):
+    def track(self, target, duration=0, announce=False, slew_only=False):
         """Simulate the track source functionality during observations.
 
         Parameters
@@ -225,7 +225,11 @@ class SimSession(object):
             The target to be tracked
         duration: int
             Duration of track
-
+        announce : bool, optional
+            True if start of action should be announced, with details of
+            settings
+        slew_only : bool, optional
+                True if only the antenna slews should be performed.
         """
         self.track_ = True
         slew_time, az, el = self._fake_slew_(target)


### PR DESCRIPTION
`mkat_session` has been updated to perform a "slow only" feature which is set in the `set_target` and `track` methods. This is useful for when slewing to the first target and we do not spend time doing setting for `fbf` - see https://github.com/ska-sa/katcorelib/pull/369 for more details.

In this PR, we update astrokat to use the "slew only" functionality when running observation.
JIRA: [MT-2952](https://skaafrica.atlassian.net/browse/MT-2952)

####  Testing before deployment
- To run the unittests for this branch, please follow this part of the README
`cd astrokat`
Python virtual environment setup
```
python3 -m venv env
source env/bin/activate
pip install nose
pip install mock
pip install -e .
```
Then head to the test directory and run the tests:
```
cd astrokat/test
`python3 -m nose .
```
For system level testing, install the branch
```
cd svn/astrokat
sudo pip install . -U --no-deps
```
Then run this schedule block
`ipython`
```python
import katuilib
configure_obs()
obs.sb.new(owner='AstroKAT')
obs.sb.type=katuilib.ScheduleBlockTypes.OBSERVATION
obs.sb.antenna_spec='available'
obs.sb.controlled_resources_spec='cbf,sdp'
obs.sb.description='nd-pattern-sim'
obs.sb.proposal_id='devel'
obs.sb.instruction_set="run-obs-script /home/kat/svn/astrokat/scripts/astrokat-observe.py --yaml /home/kat/svn/astrokat/astrokat/test/test_nd/nd-pattern-sim.yaml"
obs.sb.to_defined()
obs.sb.to_approved()
obs.sb.unload()
```


[MT-2952]: https://skaafrica.atlassian.net/browse/MT-2952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ