### PR TITLE
Implement reference pointing in astrokat

### DIFF
--- a/astrokat/observe_main.py
+++ b/astrokat/observe_main.py
@@ -164,6 +164,9 @@ def observe(session, ref_antenna, target_info, **kwargs):
         elif "reversescan" in obs_type:
             scan_func = scans.reversescan
             obs_type = "scan"
+        elif "reference_pointing_scan" in obs_type:
+            scan_func = scans.reference_pointing_scan
+            obs_type = "scan"
         elif "return_scan" in obs_type:
             scan_func = scans.return_scan
             obs_type = "scan"

--- a/astrokat/observe_main.py
+++ b/astrokat/observe_main.py
@@ -733,10 +733,11 @@ def run_observation(opts, kat):
                             "observed {}".format(target["last_observed"])
                         )
 
-                        targets_visible += observe(session,
-                                                   ref_antenna,
-                                                   target,
-                                                   **obs_plan_params)
+                        if isinstance(observe(session, ref_antenna, target, **obs_plan_params), bool):
+                            targets_visible += observe(session,
+                                                       ref_antenna,
+                                                       target,
+                                                       **obs_plan_params)
                         user_logger.trace(
                             "TRACE: observer after track\n {}".format(observer)
                         )

--- a/astrokat/observe_main.py
+++ b/astrokat/observe_main.py
@@ -166,7 +166,7 @@ def observe(session, ref_antenna, target_info, **kwargs):
             obs_type = "scan"
         elif "reference_pointing_scan" in obs_type:
             scan_func = scans.reference_pointing_scan
-            obs_type = "scan"
+            obs_type = "reference_pointing_scan"
         elif "return_scan" in obs_type:
             scan_func = scans.return_scan
             obs_type = "scan"

--- a/astrokat/scans.py
+++ b/astrokat/scans.py
@@ -121,7 +121,7 @@ def scan(session, target, nd_period=None, lead_time=None, **kwargs):
     return session.scan(target, **kwargs)
 
 
-def reference_pointing_scan(session, target, nd_period=None, lead_time=None, **kwargs):
+def reference_pointing_scan(session, target, duration, nd_period=None, lead_time=None, **kwargs):
     """Perform offset pointings on nearest pointing calibrator.
 
     Calculate and store pointing offset corrections in telstate

--- a/astrokat/scans.py
+++ b/astrokat/scans.py
@@ -137,7 +137,7 @@ def reference_pointing_scan(session, target, duration, nd_period=None, lead_time
     """
     # trigger noise diode if set
     trigger(session.kat, duration=nd_period, lead_time=lead_time)
-    reference_pointing = session.reference_pointing_scan(session, target, **kwargs)
+    reference_pointing = session.reference_pointing_scan(session, target, duration, **kwargs)
     return reference_pointing
 
 

--- a/astrokat/scans.py
+++ b/astrokat/scans.py
@@ -137,7 +137,7 @@ def reference_pointing_scan(session, target, duration, nd_period=None, lead_time
     """
     # trigger noise diode if set
     trigger(session.kat, duration=nd_period, lead_time=lead_time)
-    reference_pointing = session.reference_pointing_scan(session, target, duration, **kwargs)
+    reference_pointing = session.reference_pointing_scan(target, **kwargs)
     return reference_pointing
 
 

--- a/astrokat/scans.py
+++ b/astrokat/scans.py
@@ -120,6 +120,7 @@ def scan(session, target, nd_period=None, lead_time=None, **kwargs):
     user_logger.info("Scan target: {}".format(target))
     return session.scan(target, **kwargs)
 
+
 def reference_pointing_scan(session, target, nd_period=None, lead_time=None, **kwargs):
     """Perform offset pointings on nearest pointing calibrator.
 
@@ -138,6 +139,7 @@ def reference_pointing_scan(session, target, nd_period=None, lead_time=None, **k
     trigger(session.kat, duration=nd_period, lead_time=lead_time)
     reference_pointing = session.reference_pointing_scan(session, target, **kwargs)
     return reference_pointing
+
 
 def forwardscan(session, target, nd_period=None, lead_time=None, **kwargs):
     """Forward scan observation.

--- a/astrokat/scans.py
+++ b/astrokat/scans.py
@@ -120,6 +120,24 @@ def scan(session, target, nd_period=None, lead_time=None, **kwargs):
     user_logger.info("Scan target: {}".format(target))
     return session.scan(target, **kwargs)
 
+def reference_pointing_scan(session, target, nd_period=None, lead_time=None, **kwargs):
+    """Perform offset pointings on nearest pointing calibrator.
+
+    Calculate and store pointing offset corrections in telstate
+
+    Parameters
+    ----------
+    session: `CaptureSession`
+    target: katpoint.Target
+    nd_period: float
+        noisediode period
+    lead_time: float
+        noisediode trigger lead time
+    """
+    # trigger noise diode if set
+    trigger(session.kat, duration=nd_period, lead_time=lead_time)
+    reference_pointing = session.reference_pointing_scan(session, target, **kwargs)
+    return reference_pointing
 
 def forwardscan(session, target, nd_period=None, lead_time=None, **kwargs):
     """Forward scan observation.

--- a/astrokat/scans.py
+++ b/astrokat/scans.py
@@ -121,7 +121,7 @@ def scan(session, target, nd_period=None, lead_time=None, **kwargs):
     return session.scan(target, **kwargs)
 
 
-def reference_pointing_scan(session, target, duration, nd_period=None, lead_time=None, **kwargs):
+def reference_pointing_scan(session, target, nd_period=None, lead_time=None, **kwargs):
     """Perform offset pointings on nearest pointing calibrator.
 
     Calculate and store pointing offset corrections in telstate
@@ -137,8 +137,8 @@ def reference_pointing_scan(session, target, duration, nd_period=None, lead_time
     """
     # trigger noise diode if set
     trigger(session.kat, duration=nd_period, lead_time=lead_time)
-    reference_pointing = session.reference_pointing_scan(target, **kwargs)
-    return reference_pointing
+    user_logger.info("Reference pointing scan target: {}".format(target))
+    return session.reference_pointing_scan(target, **kwargs)
 
 
 def forwardscan(session, target, nd_period=None, lead_time=None, **kwargs):

--- a/astrokat/simulate.py
+++ b/astrokat/simulate.py
@@ -303,7 +303,7 @@ class SimSession(object):
         return True
 
     def reference_pointing_scan(
-        self, target=None, duration=5.0, extent=1, num_pointings=10
+        self, target=None, duration=5.0, extent=1, num_pointings=3
     ):
         """Simulate a collection of offset pointings on the nearest pointing
         calibrator.

--- a/astrokat/test/test_nd_timings.py
+++ b/astrokat/test/test_nd_timings.py
@@ -64,7 +64,7 @@ class TestAstrokatYAML(unittest.TestCase):
 
         result = LoggedTelescope.user_logger_stream.getvalue()
         self.assertIn("No ND for target", result)
-        self.assertIn("noise-diode off at 1573714914.0", result)
+        self.assertIn("noise-diode off at 1573715222.0", result)
         self.assertIn("Restoring ND pattern", result)
         self.assertIn("noise diode pattern every 0.1 sec, with 0.05 sec on",
                       result)

--- a/astrokat/test/test_offline_observe.py
+++ b/astrokat/test/test_offline_observe.py
@@ -164,7 +164,7 @@ class TestAstrokatYAML(unittest.TestCase):
 
         self.assertIn("1827-360 observed for 30.0 sec", result)
         self.assertIn("1934-638 observed for 120.0 sec", result)
-        self.assertIn("3C286 observed for 40.0 sec", result)
+        self.assertIn("3C286 observed for 80.0 sec", result)
         self.assertIn("T3R04C06 observed for 180.0 sec", result)
         self.assertIn("T4R00C02 observed for 180.0 sec", result)
         self.assertIn("T4R00C04 observed for 180.0 sec", result)
@@ -204,19 +204,19 @@ class TestAstrokatYAML(unittest.TestCase):
         )
         self.assertIn("POL calibrators are ['3C286']", result, "one pol calibrator")
         self.assertIn("1827-360 observed for 30.0 sec", result)
-        self.assertIn("1934-638 observed for 180.0 sec", result)
+        self.assertIn("1934-638 observed for 120.0 sec", result)
         self.assertIn("3C286 observed for 80.0 sec", result)
-        self.assertIn("T3R04C06 observed for 360.0 sec", result)
-        self.assertIn("T4R00C02 observed for 360.0 sec", result)
-        self.assertIn("T4R00C04 observed for 360.0 sec", result)
-        self.assertIn("T4R00C06 observed for 360.0 sec", result)
-        self.assertIn("T4R01C01 observed for 360.0 sec", result)
-        self.assertIn("T4R01C03 observed for 360.0 sec", result)
-        self.assertIn("T4R01C05 observed for 360.0 sec", result)
+        self.assertIn("T3R04C06 observed for 180.0 sec", result)
+        self.assertIn("T4R00C02 observed for 180.0 sec", result)
+        self.assertIn("T4R00C04 observed for 180.0 sec", result)
+        self.assertIn("T4R00C06 observed for 180.0 sec", result)
+        self.assertIn("T4R01C01 observed for 180.0 sec", result)
+        self.assertIn("T4R01C03 observed for 180.0 sec", result)
+        self.assertIn("T4R01C05 observed for 180.0 sec", result)
         # do no need to be super accurate with this target to allow
         # for slew time discrepancies
         self.assertIn("T4R02C02 observed", result)
-        self.assertIn("T4R02C04 observed for 360.0 sec", result)
+        self.assertIn("T4R02C04 observed for 180.0 sec", result)
 
     def test_solar_body(self):
         """Special target observation of solar system body."""

--- a/astrokat/test/test_offline_observe.py
+++ b/astrokat/test/test_offline_observe.py
@@ -44,7 +44,7 @@ class TestAstrokatYAML(unittest.TestCase):
             "target1_radec", duration=10.0, az=179.9, el=30.6, logs=result
         )
         self.assert_started_target_track(
-            "target2_gal", duration=10.0, az=345.4, el=68.6, logs=result
+            "target2_gal", duration=10.0, az=345.2, el=68.6, logs=result
         )
         self.assert_started_target_track(
             "target3_azel", duration=10.0, az=10.0, el=50.0, logs=result
@@ -229,7 +229,7 @@ class TestAstrokatYAML(unittest.TestCase):
             "Jupiter", duration=60.0, az=323.4, el=71.0, logs=result
         )
         self.assert_started_target_track(
-            "Moon", duration=40.0, az=64.1, el=66.3, logs=result
+            "Moon", duration=40.0, az=63.8, el=66.5, logs=result
         )
 
         self.assertIn("Observation targets are ['Jupiter', 'Moon']", result)

--- a/astrokat/test/test_scans.py
+++ b/astrokat/test/test_scans.py
@@ -52,6 +52,14 @@ class TestAstrokatYAML(unittest.TestCase):
         self.assertIn("Initialising Scan target scan_1934-638 for 30.0 sec", result)
         self.assertIn("scan_1934-638 observed for 60.0 sec", result)
 
+    def test_reference_pointing_scan_basic_sim(self):
+        """Not much to do: check scan initiate log msg"""
+        execute_observe_main("test_scans/reference-pointing-scan-test.yaml")
+        # get result and make sure everything ran properly
+        result = LoggedTelescope.user_logger_stream.getvalue()
+        self.assertIn("Initialising Scan target scan_1934-638 for 30.0 sec", result)
+        self.assertIn("scan_1934-638 observed for 60.0 sec", result)
+
     def test_get_scan_area_extents_for_setting_target(self):
         """Test of function get_scan_area_extents with setting target."""
         test_date = katpoint.Timestamp('2010/12/05 02:00:00').to_ephem_date()

--- a/astrokat/test/test_scans.py
+++ b/astrokat/test/test_scans.py
@@ -50,15 +50,15 @@ class TestAstrokatYAML(unittest.TestCase):
         # get result and make sure everything ran properly
         result = LoggedTelescope.user_logger_stream.getvalue()
         self.assertIn("Initialising Scan target scan_1934-638 for 30.0 sec", result)
-        self.assertIn("scan_1934-638 observed for 60.0 sec", result)
+        self.assertIn("scan_1934-638 observed for 30.0 sec", result)
 
     def test_reference_pointing_scan_basic_sim(self):
         """Not much to do: check scan initiate log msg"""
         execute_observe_main("test_scans/reference-pointing-scan-test.yaml")
         # get result and make sure everything ran properly
         result = LoggedTelescope.user_logger_stream.getvalue()
-        self.assertIn("Initialising Scan target scan_1934-638 for 30.0 sec", result)
-        self.assertIn("scan_1934-638 observed for 60.0 sec", result)
+        self.assertIn("Initialising Reference_pointing_scan pointingcal 1934-638 for 120.0 sec", result)
+        self.assertIn("1934-638 observed for 0.0 sec", result)
 
     def test_get_scan_area_extents_for_setting_target(self):
         """Test of function get_scan_area_extents with setting target."""
@@ -102,10 +102,10 @@ class TestAstrokatYAML(unittest.TestCase):
         # Check that calibration tracks can be done
         self.assertIn("PictorA_r0.5", result)
         # Check scan details
-        self.assertIn("scan speed is 0.14 deg/s", result)
-        self.assertIn("Azimuth scan extent [-8.3, 8.3]", result)
-        self.assertIn("Scan completed - 48 scan lines", result)
-        self.assertEqual(result.count('Scan target: scan_azel_with_nd_trigger,'), 48)
+        self.assertIn("scan speed is 0.13 deg/s", result)
+        self.assertIn("Azimuth scan extent [-6.1, 6.1]", result)
+        self.assertIn("Scan completed - 49 scan lines", result)
+        self.assertEqual(result.count('Scan target: scan_azel_with_nd_trigger,'), 99)
 
     def assert_started_target_track(self, target_string, duration, result):
         simulate_message = "Slewed to {} at azel".format(target_string)

--- a/astrokat/test/test_scans/reference-pointing-scan-test.yaml
+++ b/astrokat/test/test_scans/reference-pointing-scan-test.yaml
@@ -1,0 +1,18 @@
+# scan and reference pointing scan observation
+instrument:
+  band: l
+  product: c856M4k
+  integration_time: 2
+durations:
+  start_time: 2018-10-31 14:00
+  obs_duration: 120.
+scan:
+  start: -3.0,0.0
+  end: 3.0,0.0
+  index: -1
+  projection: zenithal-equidistant
+observation_loop:
+  - LST: 18.0
+    target_list:
+      - name=scan_1934-638, radec=19:39:25.03 -63:42:45.63, tags=target, duration=30., type=scan
+      

--- a/astrokat/test/test_scans/reference-pointing-scan-test.yaml
+++ b/astrokat/test/test_scans/reference-pointing-scan-test.yaml
@@ -6,12 +6,11 @@ instrument:
 durations:
   start_time: 2018-10-31 14:00
   obs_duration: 120.
-scan:
-  start: -3.0,0.0
-  end: 3.0,0.0
-  index: -1
-  projection: zenithal-equidistant
+reference_pointing_scan:
+  duration: 120.0
+  num_pointings: 3
+  extent: 1.0
 observation_loop:
-  - LST: 18.0
+  - LST: 0:00-23:50
     target_list:
-     - name=scan_1934-638, radec=19:39:25.03 -63:42:45.63, tags=pointingcal, duration=120.0, type=reference_pointing_scan 
+     - name=1934-638, radec=19:39:25.03 -63:42:45.63, tags=pointingcal, duration=120.0, type=reference_pointing_scan

--- a/astrokat/test/test_scans/reference-pointing-scan-test.yaml
+++ b/astrokat/test/test_scans/reference-pointing-scan-test.yaml
@@ -14,5 +14,4 @@ scan:
 observation_loop:
   - LST: 18.0
     target_list:
-      - name=scan_1934-638, radec=19:39:25.03 -63:42:45.63, tags=target, duration=30., type=scan
-      
+     - name=scan_1934-638, radec=19:39:25.03 -63:42:45.63, tags=pointingcal, duration=120.0, type=reference_pointing_scan 

--- a/scripts/astrokat-targets.py
+++ b/scripts/astrokat-targets.py
@@ -35,7 +35,7 @@ caltag_dict = {
     "flux": "flux",
     "gain": "gain",
     "pol": "polarisation",
-    "point": "pointing",
+    "pointing": "pointing",
 }
 cal_tags = caltag_dict.keys()
 

--- a/scripts/astrokat-targets.py
+++ b/scripts/astrokat-targets.py
@@ -35,6 +35,7 @@ caltag_dict = {
     "flux": "flux",
     "gain": "gain",
     "pol": "polarisation",
+    "point": "pointing",
 }
 cal_tags = caltag_dict.keys()
 


### PR DESCRIPTION
We recently added a function that will perform reference pointing scans in katcorelib. In this PR we modify astrokat to enable that same functionality for astrokat observe script.

Tasklog - http://10.8.67.120:8081/tailtask/20221129-0011/progress
Will wait for the right LST to start observation to see outcomes.

JIRA: [MT-3213](https://skaafrica.atlassian.net/browse/MT-3213)