### PR TITLE
Improve reference pointing functionality

### DIFF
--- a/astrokat/observe_main.py
+++ b/astrokat/observe_main.py
@@ -145,7 +145,6 @@ def observe(session, ref_antenna, target_info, **kwargs):
                                           lead_time=nd_lead)
     elif "reference_pointing_scan" in obs_type:
         scan_func = scans.reference_pointing_scan
-        obs_type = "reference_pointing_scan"
         target_visible = scan_func(session,
                                    target,
                                    nd_period=nd_period,

--- a/astrokat/observe_main.py
+++ b/astrokat/observe_main.py
@@ -733,10 +733,10 @@ def run_observation(opts, kat):
                             "observed {}".format(target["last_observed"])
                         )
 
-                        targets_visible += observe(session,
+                        targets_visible += bool(observe(session,
                                                    ref_antenna,
                                                    target,
-                                                   **obs_plan_params)
+                                                   **obs_plan_params))
                         user_logger.trace(
                             "TRACE: observer after track\n {}".format(observer)
                         )

--- a/astrokat/observe_main.py
+++ b/astrokat/observe_main.py
@@ -733,10 +733,10 @@ def run_observation(opts, kat):
                             "observed {}".format(target["last_observed"])
                         )
 
-                        targets_visible += bool(observe(session,
-                                                        ref_antenna,
-                                                        target,
-                                                        **obs_plan_params))
+                        targets_visible += observe(session,
+                                                   ref_antenna,
+                                                   target,
+                                                   **obs_plan_params)
                         user_logger.trace(
                             "TRACE: observer after track\n {}".format(observer)
                         )

--- a/astrokat/observe_main.py
+++ b/astrokat/observe_main.py
@@ -143,6 +143,14 @@ def observe(session, ref_antenna, target_info, **kwargs):
                                           duration=duration,
                                           nd_period=nd_period,
                                           lead_time=nd_lead)
+    elif "reference_pointing_scan" in obs_type:
+        scan_func = scans.reference_pointing_scan
+        obs_type = "reference_pointing_scan"
+        target_visible = scan_func(session,
+                                   target,
+                                   nd_period=nd_period,
+                                   lead_time=nd_lead,
+                                   **kwargs[obs_type])
     elif "scan" in obs_type:  # compensating for ' and spaces around key values
         if "raster_scan" in obs_type:
             if ("raster_scan" not in kwargs.keys()) or (
@@ -164,9 +172,6 @@ def observe(session, ref_antenna, target_info, **kwargs):
         elif "reversescan" in obs_type:
             scan_func = scans.reversescan
             obs_type = "scan"
-        elif "reference_pointing_scan" in obs_type:
-            scan_func = scans.reference_pointing_scan
-            obs_type = "reference_pointing_scan"
         elif "return_scan" in obs_type:
             scan_func = scans.return_scan
             obs_type = "scan"

--- a/astrokat/observe_main.py
+++ b/astrokat/observe_main.py
@@ -734,9 +734,9 @@ def run_observation(opts, kat):
                         )
 
                         targets_visible += bool(observe(session,
-                                                   ref_antenna,
-                                                   target,
-                                                   **obs_plan_params))
+                                                        ref_antenna,
+                                                        target,
+                                                        **obs_plan_params))
                         user_logger.trace(
                             "TRACE: observer after track\n {}".format(observer)
                         )

--- a/astrokat/observe_main.py
+++ b/astrokat/observe_main.py
@@ -733,11 +733,10 @@ def run_observation(opts, kat):
                             "observed {}".format(target["last_observed"])
                         )
 
-                        if isinstance(observe(session, ref_antenna, target, **obs_plan_params), bool):
-                            targets_visible += observe(session,
-                                                       ref_antenna,
-                                                       target,
-                                                       **obs_plan_params)
+                        targets_visible += observe(session,
+                                                   ref_antenna,
+                                                   target,
+                                                   **obs_plan_params)
                         user_logger.trace(
                             "TRACE: observer after track\n {}".format(observer)
                         )

--- a/astrokat/observe_main.py
+++ b/astrokat/observe_main.py
@@ -143,13 +143,6 @@ def observe(session, ref_antenna, target_info, **kwargs):
                                           duration=duration,
                                           nd_period=nd_period,
                                           lead_time=nd_lead)
-    elif "reference_pointing_scan" in obs_type:
-        scan_func = scans.reference_pointing_scan
-        target_visible = scan_func(session,
-                                   target,
-                                   nd_period=nd_period,
-                                   lead_time=nd_lead,
-                                   **kwargs[obs_type])
     elif "scan" in obs_type:  # compensating for ' and spaces around key values
         if "raster_scan" in obs_type:
             if ("raster_scan" not in kwargs.keys()) or (
@@ -170,6 +163,9 @@ def observe(session, ref_antenna, target_info, **kwargs):
             obs_type = "scan"
         elif "reversescan" in obs_type:
             scan_func = scans.reversescan
+            obs_type = "scan"
+        elif "reference_pointing_scan" in obs_type:
+            scan_func = scans.reference_pointing_scan
             obs_type = "scan"
         elif "return_scan" in obs_type:
             scan_func = scans.return_scan

--- a/astrokat/simulate.py
+++ b/astrokat/simulate.py
@@ -347,6 +347,7 @@ class SimSession(object):
         self.track(target, duration=0, announce=False)
         user_logger.info("Waiting for gains to materialise in cal pipeline")
         user_logger.info("Retrieving gains, fitting beams, storing offsets")
+        return True
 
     def _target_azel(self, target):
         """Get azimuth and elevation co-ordinates for a target at the current time.

--- a/astrokat/simulate.py
+++ b/astrokat/simulate.py
@@ -2,7 +2,6 @@
 from __future__ import division
 from __future__ import absolute_import
 
-import numpy as np
 import ephem
 import logging
 import numpy
@@ -309,7 +308,6 @@ class SimSession(object):
         calibrator.
         Sleep a `duration` seconds to pretend doing calculation of pointing cal solutions
         and storing them in telstate before reporting to have completed the task.
-
         Parameters
         ----------
         target: katpoint.Target object
@@ -320,11 +318,11 @@ class SimSession(object):
         num_pointings: int
             Number of offset pointings
         """
-        scan = np.linspace(-extent, extent, num_pointings // 2)
-        offsets_along_x = np.c_[scan, np.zeros_like(scan)]
-        offsets_along_y = np.c_[np.zeros_like(scan), scan]
-        offsets = np.r_[offsets_along_y, offsets_along_x]
-        offset_end_times = np.zeros(len(offsets))
+        scan = numpy.linspace(-extent, extent, num_pointings // 2)
+        offsets_along_x = numpy.c_[scan, numpy.zeros_like(scan)]
+        offsets_along_y = numpy.c_[numpy.zeros_like(scan), scan]
+        offsets = numpy.r_[offsets_along_y, offsets_along_x]
+        offset_end_times = numpy.zeros(len(offsets))
         middle_time = 0.0
         weather = {}
 

--- a/astrokat/test/test_nd_timings.py
+++ b/astrokat/test/test_nd_timings.py
@@ -64,7 +64,7 @@ class TestAstrokatYAML(unittest.TestCase):
 
         result = LoggedTelescope.user_logger_stream.getvalue()
         self.assertIn("No ND for target", result)
-        self.assertIn("noise-diode off at 1573715222.0", result)
+        self.assertIn("noise-diode off at 1573714914.0", result)
         self.assertIn("Restoring ND pattern", result)
         self.assertIn("noise diode pattern every 0.1 sec, with 0.05 sec on",
                       result)

--- a/astrokat/test/test_offline_observe.py
+++ b/astrokat/test/test_offline_observe.py
@@ -44,7 +44,7 @@ class TestAstrokatYAML(unittest.TestCase):
             "target1_radec", duration=10.0, az=179.9, el=30.6, logs=result
         )
         self.assert_started_target_track(
-            "target2_gal", duration=10.0, az=345.2, el=68.6, logs=result
+            "target2_gal", duration=10.0, az=345.4, el=68.6, logs=result
         )
         self.assert_started_target_track(
             "target3_azel", duration=10.0, az=10.0, el=50.0, logs=result
@@ -164,7 +164,7 @@ class TestAstrokatYAML(unittest.TestCase):
 
         self.assertIn("1827-360 observed for 30.0 sec", result)
         self.assertIn("1934-638 observed for 120.0 sec", result)
-        self.assertIn("3C286 observed for 80.0 sec", result)
+        self.assertIn("3C286 observed for 40.0 sec", result)
         self.assertIn("T3R04C06 observed for 180.0 sec", result)
         self.assertIn("T4R00C02 observed for 180.0 sec", result)
         self.assertIn("T4R00C04 observed for 180.0 sec", result)
@@ -204,19 +204,19 @@ class TestAstrokatYAML(unittest.TestCase):
         )
         self.assertIn("POL calibrators are ['3C286']", result, "one pol calibrator")
         self.assertIn("1827-360 observed for 30.0 sec", result)
-        self.assertIn("1934-638 observed for 120.0 sec", result)
+        self.assertIn("1934-638 observed for 180.0 sec", result)
         self.assertIn("3C286 observed for 80.0 sec", result)
-        self.assertIn("T3R04C06 observed for 180.0 sec", result)
-        self.assertIn("T4R00C02 observed for 180.0 sec", result)
-        self.assertIn("T4R00C04 observed for 180.0 sec", result)
-        self.assertIn("T4R00C06 observed for 180.0 sec", result)
-        self.assertIn("T4R01C01 observed for 180.0 sec", result)
-        self.assertIn("T4R01C03 observed for 180.0 sec", result)
-        self.assertIn("T4R01C05 observed for 180.0 sec", result)
+        self.assertIn("T3R04C06 observed for 360.0 sec", result)
+        self.assertIn("T4R00C02 observed for 360.0 sec", result)
+        self.assertIn("T4R00C04 observed for 360.0 sec", result)
+        self.assertIn("T4R00C06 observed for 360.0 sec", result)
+        self.assertIn("T4R01C01 observed for 360.0 sec", result)
+        self.assertIn("T4R01C03 observed for 360.0 sec", result)
+        self.assertIn("T4R01C05 observed for 360.0 sec", result)
         # do no need to be super accurate with this target to allow
         # for slew time discrepancies
         self.assertIn("T4R02C02 observed", result)
-        self.assertIn("T4R02C04 observed for 180.0 sec", result)
+        self.assertIn("T4R02C04 observed for 360.0 sec", result)
 
     def test_solar_body(self):
         """Special target observation of solar system body."""
@@ -229,7 +229,7 @@ class TestAstrokatYAML(unittest.TestCase):
             "Jupiter", duration=60.0, az=323.4, el=71.0, logs=result
         )
         self.assert_started_target_track(
-            "Moon", duration=40.0, az=63.8, el=66.5, logs=result
+            "Moon", duration=40.0, az=64.1, el=66.3, logs=result
         )
 
         self.assertIn("Observation targets are ['Jupiter', 'Moon']", result)

--- a/astrokat/test/test_scans.py
+++ b/astrokat/test/test_scans.py
@@ -58,7 +58,7 @@ class TestAstrokatYAML(unittest.TestCase):
         # get result and make sure everything ran properly
         result = LoggedTelescope.user_logger_stream.getvalue()
         self.assertIn("Initialising Reference_pointing_scan pointingcal 1934-638 for 120.0 sec", result)
-        self.assertIn("1934-638 observed for 0.0 sec", result)
+        self.assertIn("1934-638 observed for 120.0 sec", result)
 
     def test_get_scan_area_extents_for_setting_target(self):
         """Test of function get_scan_area_extents with setting target."""

--- a/astrokat/test/test_scans.py
+++ b/astrokat/test/test_scans.py
@@ -50,7 +50,7 @@ class TestAstrokatYAML(unittest.TestCase):
         # get result and make sure everything ran properly
         result = LoggedTelescope.user_logger_stream.getvalue()
         self.assertIn("Initialising Scan target scan_1934-638 for 30.0 sec", result)
-        self.assertIn("scan_1934-638 observed for 30.0 sec", result)
+        self.assertIn("scan_1934-638 observed for 60.0 sec", result)
 
     def test_reference_pointing_scan_basic_sim(self):
         """Not much to do: check scan initiate log msg"""
@@ -102,10 +102,10 @@ class TestAstrokatYAML(unittest.TestCase):
         # Check that calibration tracks can be done
         self.assertIn("PictorA_r0.5", result)
         # Check scan details
-        self.assertIn("scan speed is 0.13 deg/s", result)
-        self.assertIn("Azimuth scan extent [-6.1, 6.1]", result)
-        self.assertIn("Scan completed - 49 scan lines", result)
-        self.assertEqual(result.count('Scan target: scan_azel_with_nd_trigger,'), 99)
+        self.assertIn("scan speed is 0.14 deg/s", result)
+        self.assertIn("Azimuth scan extent [-8.3, 8.3]", result)
+        self.assertIn("Scan completed - 48 scan lines", result)
+        self.assertEqual(result.count('Scan target: scan_azel_with_nd_trigger,'), 48)
 
     def assert_started_target_track(self, target_string, duration, result):
         simulate_message = "Slewed to {} at azel".format(target_string)


### PR DESCRIPTION
The function call to `reference_pointing_scan` was placed among the "scans" and led to a confusion in how many tracks of the target during calls `reversescan`. We now move the check if the observation is "reference_pointing" to earlier in our logic.

Reference pointing gives the expected telstateError result - http://10.8.67.104:8081/tailtask/20230206-0001/progress

#### Before fix
[MASTER.txt](https://github.com/ska-sa/astrokat/files/10667766/MASTER.txt)

#### After fix
[after_fix.txt](https://github.com/ska-sa/astrokat/files/10667761/after_fix.txt)


JIRA: [MT-3289](https://skaafrica.atlassian.net/browse/MT-3289)

[MT-3289]: https://skaafrica.atlassian.net/browse/MT-3289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ