### PR TITLE
Hotfix V30: Improve reference pointing functionality

### DIFF
--- a/astrokat/observe_main.py
+++ b/astrokat/observe_main.py
@@ -165,6 +165,9 @@ def observe(session, ref_antenna, target_info, **kwargs):
         elif "reversescan" in obs_type:
             scan_func = scans.reversescan
             obs_type = "scan"
+        elif "reference_pointing_scan" in obs_type:
+            scan_func = scans.reference_pointing_scan
+            obs_type = "scan"
         elif "return_scan" in obs_type:
             scan_func = scans.return_scan
             obs_type = "scan"

--- a/astrokat/simulate.py
+++ b/astrokat/simulate.py
@@ -297,6 +297,54 @@ class SimSession(object):
         time.sleep(duration)
         return True
 
+    def reference_pointing_scan(
+        self, target=None, duration=5.0, extent=1, num_pointings=3
+    ):
+        """Simulate a collection of offset pointings on the nearest pointing
+        calibrator.
+        Sleep a `duration` seconds to pretend doing calculation of pointing cal solutions
+        and storing them in telstate before reporting to have completed the task.
+        Parameters
+        ----------
+        target: katpoint.Target object
+        duration: int or float
+            Duration of scan
+        extent: int/float
+            distance of offset from target, in degrees
+        num_pointings: int
+            Number of offset pointings
+        """
+        scan = numpy.linspace(-extent, extent, num_pointings // 2)
+        offsets_along_x = numpy.c_[scan, numpy.zeros_like(scan)]
+        offsets_along_y = numpy.c_[numpy.zeros_like(scan), scan]
+        offsets = numpy.r_[offsets_along_y, offsets_along_x]
+        offset_end_times = numpy.zeros(len(offsets))
+        middle_time = 0.0
+        weather = {}
+
+        user_logger.info(
+            "Initiating interferometric pointing scan on target "
+            "'%s' (%d pointings of %g seconds each)",
+            target.name,
+            len(offsets),
+            duration,
+        )
+        self.track(target, duration=0, announce=False)
+        # Point to the requested offsets and collect extra data at middle time
+        for n, offset in enumerate(offsets):
+            user_logger.info("initiating track on offset of (%g, %g) degrees", *offset)
+            self.track(target, duration, announce=False)
+            offset_end_times[n] = time.time()
+            if n == len(offsets) // 2 - 1:
+                middle_time = offset_end_times[n]
+                user_logger.info(
+                    "reference time = %.1f, weather = %r", middle_time, weather)
+        user_logger.info("returning to target to complete the scan")
+        self.track(target, duration=0, announce=False)
+        user_logger.info("Waiting for gains to materialise in cal pipeline")
+        user_logger.info("Retrieving gains, fitting beams, storing offsets")
+        return True
+
     def _target_azel(self, target):
         """Get azimuth and elevation co-ordinates for a target at the current time.
 

--- a/astrokat/test/test_scans.py
+++ b/astrokat/test/test_scans.py
@@ -52,6 +52,14 @@ class TestAstrokatYAML(unittest.TestCase):
         self.assertIn("Initialising Scan target scan_1934-638 for 30.0 sec", result)
         self.assertIn("scan_1934-638 observed for 60.0 sec", result)
 
+    def test_reference_pointing_scan_basic_sim(self):
+        """Not much to do: check scan initiate log msg"""
+        execute_observe_main("test_scans/reference-pointing-scan-test.yaml")
+        # get result and make sure everything ran properly
+        result = LoggedTelescope.user_logger_stream.getvalue()
+        self.assertIn("Initialising Reference_pointing_scan pointingcal 1934-638 for 120.0 sec", result)
+        self.assertIn("1934-638 observed for 120.0 sec", result)
+
     def test_get_scan_area_extents_for_setting_target(self):
         """Test of function get_scan_area_extents with setting target."""
         test_date = katpoint.Timestamp('2010/12/05 02:00:00').to_ephem_date()


### PR DESCRIPTION
The function call to `reference_pointing_scan` was placed among the "scans" and led to a confusion in how many tracks of the target during calls `reversescan`. We now move the check if the observation is "reference_pointing" to earlier in our logic.

Reference pointing gives the expected telstateError result - http://10.8.67.104:8081/tailtask/20230206-0001/progress


JIRA: [MT-3289](https://skaafrica.atlassian.net/browse/MT-3289)