### PR TITLE
Issue noisediode deactivation to happen now

### DIFF
--- a/astrokat/noisediode.py
+++ b/astrokat/noisediode.py
@@ -194,13 +194,8 @@ def nd_reset(kat,
     timestamp : float
         Linux timestamp reported by digitiser
     """
-    antennas = sorted(ant.name for ant in kat.ants)
     user_logger.info('Resetting all noise diodes')
-    # TODO - bngcebetsha: do we want to do this for ALL antennas or a targeted group such
-    # as is done in `_set_dig_nd_()`?
-    for ant in antennas:
-        ped = getattr(kat, ant)
-        ped.req.dig_noise_source(timestamp, switch)
+    kat.ants.req.dig_noise_source(timestamp, switch)
 
 
 def _switch_on_off_(kat,

--- a/astrokat/noisediode.py
+++ b/astrokat/noisediode.py
@@ -195,7 +195,7 @@ def nd_reset(kat,
         Linux timestamp reported by digitiser
     """
     antennas = sorted(ant.name for ant in kat.ants)
-    user_logger.info('Switching off all noise diodes')
+    user_logger.info('Resetting all noise diodes')
     # TODO - bngcebetsha: do we want to do this for ALL antennas or a targeted group such
     # as is done in `_set_dig_nd_()`?
     for ant in antennas:

--- a/astrokat/noisediode.py
+++ b/astrokat/noisediode.py
@@ -103,6 +103,10 @@ def _set_dig_nd_(kat,
         replies[ant] = ped.req.dig_noise_source(timestamp,
                                                 on_fraction,
                                                 cycle_length)
+        # TODO - bngcebetsha: update the switcing off of noise diodes to happen 'now' in
+        # order to avoid attempting to set them when the `timestamp` is in the past.
+        # user_logger.info('Switching off all noise diodes')
+        # replies[ant] = ped.req.dig_noise_source('now', 0)
         if kat.dry_run:
             msg = ('Dry-run: Set noise diode for antenna {} at '
                    'timestamp {}'.format(ant, timestamp))

--- a/astrokat/noisediode.py
+++ b/astrokat/noisediode.py
@@ -103,10 +103,6 @@ def _set_dig_nd_(kat,
         replies[ant] = ped.req.dig_noise_source(timestamp,
                                                 on_fraction,
                                                 cycle_length)
-        # TODO - bngcebetsha: update the switcing off of noise diodes to happen 'now' in
-        # order to avoid attempting to set them when the `timestamp` is in the past.
-        # user_logger.info('Switching off all noise diodes')
-        # replies[ant] = ped.req.dig_noise_source('now', 0)
         if kat.dry_run:
             msg = ('Dry-run: Set noise diode for antenna {} at '
                    'timestamp {}'.format(ant, timestamp))
@@ -177,6 +173,33 @@ def _nd_log_msg_(ant,
     user_logger.debug(msg)
 
     return actual_time
+
+
+def nd_reset(kat,
+             timestamp,
+             switch=0):
+    """Reset noise-source on or off.
+
+    Parameters
+    ----------
+    kat : session kat container-like object
+        Container for accessing KATCP resources allocated to schedule block.
+    timestamp : float, optional
+        Time since the epoch as a floating point number [sec]
+    switch: int, optional
+        off = 0 (default), on = 1
+
+    Returns
+    -------
+    timestamp : float
+        Linux timestamp reported by digitiser
+    """
+    antennas = sorted(ant.name for ant in kat.ants)
+    user_logger.info('Switching off all noise diodes')
+    # TODO - bngcebetsha: do we want to do this for ALL antennas or a targeted group such
+    # as is done in `_set_dig_nd_()`?
+    for ant in antennas:
+        ant.req.dig_noise_source(timestamp, switch)
 
 
 def _switch_on_off_(kat,

--- a/astrokat/noisediode.py
+++ b/astrokat/noisediode.py
@@ -176,7 +176,7 @@ def _nd_log_msg_(ant,
 
 
 def nd_reset(kat,
-             timestamp,
+             timestamp="now",
              switch=0):
     """Reset noise-source on or off.
 
@@ -188,13 +188,10 @@ def nd_reset(kat,
         Time since the epoch as a floating point number [sec]
     switch: int, optional
         off = 0 (default), on = 1
-
-    Returns
-    -------
-    timestamp : float
-        Linux timestamp reported by digitiser
     """
-    user_logger.info('Resetting all noise diodes')
+    on_off = {0: 'off', 1: 'on'}
+    user_logger.info('Resetting all noise diodes to "{}"'
+                     .format(on_off[switch]))
     kat.ants.req.dig_noise_source(timestamp, switch)
 
 

--- a/astrokat/noisediode.py
+++ b/astrokat/noisediode.py
@@ -199,7 +199,8 @@ def nd_reset(kat,
     # TODO - bngcebetsha: do we want to do this for ALL antennas or a targeted group such
     # as is done in `_set_dig_nd_()`?
     for ant in antennas:
-        ant.req.dig_noise_source(timestamp, switch)
+        ped = getattr(kat, ant)
+        ped.req.dig_noise_source(timestamp, switch)
 
 
 def _switch_on_off_(kat,

--- a/astrokat/observe_main.py
+++ b/astrokat/observe_main.py
@@ -312,7 +312,7 @@ class Telescope(object):
         # TODO: Return correlator settings to entry values
         # switch noise-source pattern off (ensure this after each observation)
         # if NaN returned at off command, allow to continue
-        noisediode.nd_reset(self.array)
+        noisediode.nd_reset(self.array, time.time())
         # noisediode.off(self.array, allow_ts_err=True)
         self.array.disconnect()
 

--- a/astrokat/observe_main.py
+++ b/astrokat/observe_main.py
@@ -312,8 +312,7 @@ class Telescope(object):
         # TODO: Return correlator settings to entry values
         # switch noise-source pattern off (ensure this after each observation)
         # if NaN returned at off command, allow to continue
-        noisediode.nd_reset(self.array, time.time())
-        # noisediode.off(self.array, allow_ts_err=True)
+        noisediode.nd_reset(self.array, "now")
         self.array.disconnect()
 
     def subarray_setup(self, instrument):

--- a/astrokat/observe_main.py
+++ b/astrokat/observe_main.py
@@ -296,10 +296,6 @@ class Telescope(object):
         if "instrument" in obs_plan_params:
             self.subarray_setup(obs_plan_params["instrument"])
 
-        # TODO: noise diode implementations should be moved to sessions
-        # switch noise-source pattern off (known setup starting observation)
-        noisediode.off(self.array)
-
         # TODO: update correlator settings
         # TODO: names of antennas to use for beamformer if not all is desirable
         return self

--- a/astrokat/observe_main.py
+++ b/astrokat/observe_main.py
@@ -312,7 +312,8 @@ class Telescope(object):
         # TODO: Return correlator settings to entry values
         # switch noise-source pattern off (ensure this after each observation)
         # if NaN returned at off command, allow to continue
-        noisediode.off(self.array, allow_ts_err=True)
+        noisediode.nd_reset(self.array)
+        # noisediode.off(self.array, allow_ts_err=True)
         self.array.disconnect()
 
     def subarray_setup(self, instrument):


### PR DESCRIPTION
As reported in [OPS-2080](https://skaafrica.atlassian.net/browse/OPS-2080), the observation script switches the noisediodes off at the end of observations. There have been issues on site where lost connection to a receptor results in failure to switch the noisediodes off on all other antennas on the array, which reports a failure. Here we attempt to mitigate that by using the current time as the time to reset the noisediode.

## PLEASE NOTE
We still need to test this, so please take this as a draft PR.

JIRA: [MT-3844](https://skaafrica.atlassian.net/browse/MT-3844)

[OPS-2080]: https://skaafrica.atlassian.net/browse/OPS-2080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MT-3844]: https://skaafrica.atlassian.net/browse/MT-3844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ