### PR TITLE
Add function to turn off noisediodes using the 'now' timestamp

### DIFF
--- a/astrokat/noisediode.py
+++ b/astrokat/noisediode.py
@@ -175,6 +175,25 @@ def _nd_log_msg_(ant,
     return actual_time
 
 
+def nd_reset(kat,
+             timestamp="now",
+             switch=0):
+    """Reset noise-source on or off.
+    Parameters
+    ----------
+    kat : session kat container-like object
+        Container for accessing KATCP resources allocated to schedule block.
+    timestamp : float, optional
+        Time since the epoch as a floating point number [sec]
+    switch: int, optional
+        off = 0 (default), on = 1
+    """
+    on_off = {0: 'off', 1: 'on'}
+    user_logger.info('Resetting all noise diodes to "{}"'
+                     .format(on_off[switch]))
+    kat.ants.req.dig_noise_source(timestamp, switch)
+
+
 def _switch_on_off_(kat,
                     timestamp,
                     switch=0):

--- a/astrokat/observe_main.py
+++ b/astrokat/observe_main.py
@@ -297,10 +297,6 @@ class Telescope(object):
         if "instrument" in obs_plan_params:
             self.subarray_setup(obs_plan_params["instrument"])
 
-        # TODO: noise diode implementations should be moved to sessions
-        # switch noise-source pattern off (known setup starting observation)
-        noisediode.off(self.array)
-
         # TODO: update correlator settings
         # TODO: names of antennas to use for beamformer if not all is desirable
         return self
@@ -313,7 +309,7 @@ class Telescope(object):
         # TODO: Return correlator settings to entry values
         # switch noise-source pattern off (ensure this after each observation)
         # if NaN returned at off command, allow to continue
-        noisediode.off(self.array, allow_ts_err=True)
+        noisediode.nd_reset(self.array, "now")
         self.array.disconnect()
 
     def subarray_setup(self, instrument):


### PR DESCRIPTION
This PR adds a function to turn off noisediodes using the "now" timestamp. Also, the call to turn off noise diodes is added at the end of the schedule block and removed from the beginning. The action of turning off noisediodes at the beginning of the schedule block is already done by mkat session as part of the standard setup.

This PR adds the work from https://github.com/ska-sa/astrokat/pull/118 to the release branch and addresses the issue reported in [OPS-2080](https://skaafrica.atlassian.net/browse/OPS-2080)

[OPS-2080]: https://skaafrica.atlassian.net/browse/OPS-2080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ