### PR TITLE
Fix Timestamp issue on driftscan

### DIFF
--- a/astrokat/scans.py
+++ b/astrokat/scans.py
@@ -32,7 +32,7 @@ def drift_pointing_offset(ref_antenna, target, duration=60.0):
 
     """
     obs_start_ts = ref_antenna.observer.date
-    transit_time = obs_start_ts + duration / 2.0
+    transit_time = (katpoint.Timestamp(obs_start_ts) + duration / 2.0).to_ephem_date()
     # Stationary transit point becomes new target
     az, el = target.azel(timestamp=transit_time, antenna=ref_antenna)
     target = katpoint.construct_azel_target(katpoint.wrap_angle(az), el)

--- a/astrokat/test/test_scans.py
+++ b/astrokat/test/test_scans.py
@@ -32,7 +32,7 @@ class TestAstrokatYAML(unittest.TestCase):
         result = LoggedTelescope.user_logger_stream.getvalue()
         self.assertIn("Initialising Drift_scan target 1934-638 for 180.0 sec", result)
         self.assertIn("Drift_scan observation for 180.0 sec", result)
-        target_string = "Az: -172:57:37.1 El: 56:27:26.4"
+        target_string = "Az: -158:55:32.5 El: 52:01:18.0"
         self.assert_started_target_track(target_string, 180.0, result)
         self.assert_completed_target_track(target_string, 180.0, result)
 


### PR DESCRIPTION
This bug was raised in ticket  #120 

Adding an float  to a ephem_date date object returns an float number of days from 1900 plus the float value. 
This when passed to a katpoint target object is interpreted as a unix epoch,  number of seconds from 1970.  
There are two bugs in the code : 
1. First the duration that is added is in seconds but when added to ephem_date is interperated as days. 
2. Second the result which is days is assumed to be unix epoch seconds. 
 
This is fixed by first converting the ephem_date object to a katpoint.Timestamp object then adding the float number of seconds. Then using  the to_ephem_date method of the katpoint.Timestamp to convert it back.