### PR TITLE
SPR1-3072: Refresh reference pointing YAML API

### DIFF
--- a/astrokat/test/test_scans.py
+++ b/astrokat/test/test_scans.py
@@ -57,8 +57,9 @@ class TestAstrokatYAML(unittest.TestCase):
         execute_observe_main("test_scans/reference-pointing-scan-test.yaml")
         # get result and make sure everything ran properly
         result = LoggedTelescope.user_logger_stream.getvalue()
-        self.assertIn("Initialising Reference_pointing_scan pointingcal 1934-638 for 120.0 sec", result)
-        self.assertIn("1934-638 observed for 120.0 sec", result)
+        self.assertIn("Initialising Reference_pointing_scan pointingcal 1934-638 for 144.0 sec", result)
+        self.assertIn("1934-638 observed for 144.0 sec", result) 
+        self.assertIn("Adjust pointing selected", result)
 
     def test_get_scan_area_extents_for_setting_target(self):
         """Test of function get_scan_area_extents with setting target."""

--- a/astrokat/test/test_scans.py
+++ b/astrokat/test/test_scans.py
@@ -57,8 +57,9 @@ class TestAstrokatYAML(unittest.TestCase):
         execute_observe_main("test_scans/reference-pointing-scan-test.yaml")
         # get result and make sure everything ran properly
         result = LoggedTelescope.user_logger_stream.getvalue()
-        self.assertIn("Initialising Reference_pointing_scan pointingcal 1934-638 for 144.0 sec", result)
-        self.assertIn("1934-638 observed for 144.0 sec", result) 
+        self.assertIn("Initialising Reference_pointing_scan pointingcal "
+                      "1934-638 for 144.0 sec", result)
+        self.assertIn("1934-638 observed for 144.0 sec", result)
         self.assertIn("Adjust pointing selected", result)
 
     def test_get_scan_area_extents_for_setting_target(self):

--- a/astrokat/test/test_scans/reference-pointing-scan-test.yaml
+++ b/astrokat/test/test_scans/reference-pointing-scan-test.yaml
@@ -5,12 +5,17 @@ instrument:
   integration_time: 2
 durations:
   start_time: 2018-10-31 14:00
-  obs_duration: 120.
+  obs_duration: 432.0
 reference_pointing_scan:
-  duration: 120.0
-  num_pointings: 3
+  num_pointings: 9
   extent: 1.0
+reference_pointing:
+  adjust_pointing: true
+  pointing_solution_max_age: 3600
+  pointing_solution_max_dist: 15
 observation_loop:
   - LST: 0:00-23:50
     target_list:
-     - name=1934-638, radec=19:39:25.03 -63:42:45.63, tags=pointingcal, duration=120.0, type=reference_pointing_scan
+     - name=1934-638, radec=19:39:25.03 -63:42:45.63, tags=pointingcal, duration=144.0, type=reference_pointing_scan
+     - name=1934-638, radec=19:39:25.03 -63:42:45.63, tags=pointingcal, duration=144.0, type=reference_pointing_scan
+     - name=1934-638, radec=19:39:25.03 -63:42:45.63, tags=pointingcal, duration=144.0, type=reference_pointing_scan


### PR DESCRIPTION
- Obtain scan parameters from `reference_pointing_scan` section in YAML.
- Use target_list `duration` as scan duration instead of duplicating it.
- Add `reference_pointing` section in YAML to adjust the pointing.

Update the unit tests to reflect this.

This addresses ticket SPR1-3072.