### PR TITLE
SPR1-3207: Refresh reference pointing YAML API

### DIFF
--- a/astrokat/observe_main.py
+++ b/astrokat/observe_main.py
@@ -167,7 +167,11 @@ def observe(session, ref_antenna, target_info, **kwargs):
             obs_type = "scan"
         elif "reference_pointing_scan" in obs_type:
             scan_func = scans.reference_pointing_scan
-            obs_type = "scan"
+            obs_type = "reference_pointing_scan"
+            if obs_type not in kwargs.keys():
+                kwargs[obs_type] = {'duration': duration}
+            else:
+                kwargs[obs_type]['duration'] = duration
         elif "return_scan" in obs_type:
             scan_func = scans.return_scan
             obs_type = "scan"
@@ -242,9 +246,7 @@ def above_horizon(target,
     # must be celestial target (ra, dec)
     # check that target is visible at start of track
     start_ = timestamp2datetime(time.time())
-    [azim, elev] = _horizontal_coordinates(target,
-                                              observer,
-                                              start_)
+    [azim, elev] = _horizontal_coordinates(target, observer, start_)
     user_logger.trace(
         "TRACE: target at start (az, el)= ({}, {})".format(azim, elev)
     )
@@ -254,9 +256,7 @@ def above_horizon(target,
     # check that target will be visible at end of track
     if duration:
         end_ = timestamp2datetime(time.time() + duration)
-        [azim, elev] = _horizontal_coordinates(target,
-                                                  observer,
-                                                  end_)
+        [azim, elev] = _horizontal_coordinates(target, observer, end_)
         user_logger.trace(
             "TRACE: target at end (az, el)= ({}, {})".format(azim, elev)
         )
@@ -413,6 +413,17 @@ def run_observation(opts, kat):
         if "proposal_description" in vars(opts):
             description = opts.proposal_description
         session_opts["description"] = description
+
+    if "reference_pointing" in obs_plan_params:
+        user_logger.info("Adjust pointing selected")
+        refpoint_params = obs_plan_params["reference_pointing"]
+        adjust_pointing = refpoint_params["adjust_pointing"]
+        max_age = refpoint_params["pointing_solution_max_age"]
+        max_dist = refpoint_params["pointing_solution_max_dist"]
+        session_opts = vars(opts)
+        session_opts["adjust_pointing"] = adjust_pointing
+        session_opts["pointing_solution_max_age"] = max_age
+        session_opts["pointing_solution_max_dist"] = max_dist
 
     nr_obs_loops = len(obs_plan_params["observation_loop"])
     with start_session(kat.array, **vars(opts)) as session:

--- a/astrokat/test/test_scans.py
+++ b/astrokat/test/test_scans.py
@@ -57,9 +57,9 @@ class TestAstrokatYAML(unittest.TestCase):
         execute_observe_main("test_scans/reference-pointing-scan-test.yaml")
         # get result and make sure everything ran properly
         result = LoggedTelescope.user_logger_stream.getvalue()
-        self.assertIn("Initialising Reference_pointing_scan pointingcal "
-                      "1934-638 for 120.0 sec", result)
-        self.assertIn("1934-638 observed for 120.0 sec", result)
+        self.assertIn("Initialising Reference_pointing_scan pointingcal 1934-638 for 144.0 sec", result)
+        self.assertIn("1934-638 observed for 144.0 sec", result) 
+        self.assertIn("Adjust pointing selected", result)
 
     def test_get_scan_area_extents_for_setting_target(self):
         """Test of function get_scan_area_extents with setting target."""

--- a/astrokat/test/test_scans.py
+++ b/astrokat/test/test_scans.py
@@ -57,8 +57,9 @@ class TestAstrokatYAML(unittest.TestCase):
         execute_observe_main("test_scans/reference-pointing-scan-test.yaml")
         # get result and make sure everything ran properly
         result = LoggedTelescope.user_logger_stream.getvalue()
-        self.assertIn("Initialising Reference_pointing_scan pointingcal 1934-638 for 144.0 sec", result)
-        self.assertIn("1934-638 observed for 144.0 sec", result) 
+        self.assertIn("Initialising Reference_pointing_scan pointingcal "
+                      "1934-638 for 144.0 sec", result)
+        self.assertIn("1934-638 observed for 144.0 sec", result)
         self.assertIn("Adjust pointing selected", result)
 
     def test_get_scan_area_extents_for_setting_target(self):

--- a/astrokat/test/test_scans/reference-pointing-scan-test.yaml
+++ b/astrokat/test/test_scans/reference-pointing-scan-test.yaml
@@ -5,12 +5,17 @@ instrument:
   integration_time: 2
 durations:
   start_time: 2018-10-31 14:00
-  obs_duration: 120.
+  obs_duration: 432.0
 reference_pointing_scan:
-  duration: 120.0
-  num_pointings: 3
+  num_pointings: 9
   extent: 1.0
+reference_pointing:
+  adjust_pointing: true
+  pointing_solution_max_age: 3600
+  pointing_solution_max_dist: 15
 observation_loop:
   - LST: 0:00-23:50
     target_list:
-     - name=1934-638, radec=19:39:25.03 -63:42:45.63, tags=pointingcal, duration=120.0, type=reference_pointing_scan
+     - name=1934-638, radec=19:39:25.03 -63:42:45.63, tags=pointingcal, duration=144.0, type=reference_pointing_scan
+     - name=1934-638, radec=19:39:25.03 -63:42:45.63, tags=pointingcal, duration=144.0, type=reference_pointing_scan
+     - name=1934-638, radec=19:39:25.03 -63:42:45.63, tags=pointingcal, duration=144.0, type=reference_pointing_scan


### PR DESCRIPTION
- Obtain scan parameters from `reference_pointing_scan` section in YAML.
- Use target_list `duration` as scan duration instead of duplicating it.
- Add `reference_pointing` section in YAML to adjust the pointing.

Update the unit tests to reflect this.

This addresses ticket SPR1-3207.

(Released version of #127)
