### PR TITLE
feat: add new constant elevation scans.

### DIFF
--- a/astrokat/observe_main.py
+++ b/astrokat/observe_main.py
@@ -172,7 +172,7 @@ def observe(session, ref_antenna, target_info, **kwargs):
             obs_type = "scan"
         elif obs_type == "scan_const_el":
             scan_func = scans.scan_const_el
-            obs_type = "scan"            
+            obs_type = "scan"
         elif obs_type == "reference_pointing_scan":
             scan_func = scans.reference_pointing_scan
             obs_type = "reference_pointing_scan"

--- a/astrokat/observe_main.py
+++ b/astrokat/observe_main.py
@@ -158,23 +158,32 @@ def observe(session, ref_antenna, target_info, **kwargs):
             else:
                 kwargs['scan']['duration'] = duration
         # TODO: fix raster scan and remove this scan hack
-        if "forwardscan" in obs_type:
+        if obs_type == "forwardscan":
             scan_func = scans.forwardscan
             obs_type = "scan"
-        elif "reversescan" in obs_type:
+        elif obs_type == "reversescan":
             scan_func = scans.reversescan
             obs_type = "scan"
-        elif "reference_pointing_scan" in obs_type:
+        elif obs_type == "multi_scan_target_el":
+            scan_func = scans.multi_scan_target_el
+            obs_type = "scan"
+        elif obs_type == "multi_scan_const_el":
+            scan_func = scans.multi_scan_const_el
+            obs_type = "scan"
+        elif obs_type == "scan_const_el":
+            scan_func = scans.scan_const_el
+            obs_type = "scan"            
+        elif obs_type == "reference_pointing_scan":
             scan_func = scans.reference_pointing_scan
             obs_type = "reference_pointing_scan"
             if obs_type not in kwargs.keys():
                 kwargs[obs_type] = {'duration': duration}
             else:
                 kwargs[obs_type]['duration'] = duration
-        elif "return_scan" in obs_type:
+        elif obs_type == "return_scan":
             scan_func = scans.return_scan
             obs_type = "scan"
-        elif "raster_scan" in obs_type:
+        elif obs_type == "raster_scan":
             scan_func = scans.raster_scan
         else:
             scan_func = scans.scan

--- a/astrokat/scans.py
+++ b/astrokat/scans.py
@@ -144,14 +144,16 @@ def scan_const_el(session, target, nd_period=None, lead_time=None, **kwargs):
     """
     required_params = ['scan_width_radec', 'scan_speed_radec']
     if not all(k in kwargs for k in required_params):
-        raise ValueError("Constant elevation scan requires {} in YAML config".format(required_params))
+        raise ValueError(
+            "Constant elevation scan requires {} in YAML config".format(required_params)
+        )
 
     # trigger noise diode if set
     trigger(session.kat, duration=nd_period, lead_time=lead_time)
 
     scan_width_radec = float(kwargs['scan_width_radec'])  # degrees in RA/Dec
     scan_speed_radec = float(kwargs['scan_speed_radec'])  # arcmin/sec in RA/Dec
-    
+
     # Calculate scan duration in seconds (no elevation conversion needed)
     scan_duration = scan_width_radec / scan_speed_radec * 60
 
@@ -166,40 +168,43 @@ def scan_const_el(session, target, nd_period=None, lead_time=None, **kwargs):
     scan_start_buffer = 3.0  # seconds
     scan_mid_ts = timestamp + scan_start_buffer + scan_duration / 2.0
     az_rad, el_rad = target.azel(timestamp=scan_mid_ts)
-        
+
     # Convert RA/Dec width to azimuth width for initial positioning (rough estimate)
     scan_width_az_initial = scan_width_radec / np.cos(el_rad)
-    
+
     # Calculate scan start position (offset from center)
     start_az_offset = -scan_width_az_initial / 2.0
     start_az_rad = katpoint.wrap_angle(az_rad + np.radians(start_az_offset))
-    
+
     # Create target at scan start position for pre-positioning
     scan_start_target = katpoint.construct_azel_target(start_az_rad, el_rad)
     scan_start_target.name = target.name
     scan_start_target.antenna = target.antenna
-    
-    user_logger.info("Pre-positioning to scan start (Az, El): ({:.2f}, {:.2f}) deg".format(
-        np.degrees(start_az_rad), np.degrees(el_rad)))
-    
+
+    user_logger.info(
+        "Pre-positioning to scan start (Az, El): ({:.2f}, {:.2f}) deg".format(
+            np.degrees(start_az_rad), np.degrees(el_rad)
+        )
+    )
+
     # Pre-position telescope to scan start with minimal slewing during scan
     target_visible = session.track(scan_start_target, duration=0.0, announce=False)
     if not target_visible:
         user_logger.warning("Scan start position not visible")
         return False
-    
+
     # After slewing, recalculate target position at scan center for actual scan
     try:
         current_timestamp = session.time
     except AttributeError:
         current_timestamp = time.time()
-    
+
     scan_mid_ts = current_timestamp + scan_start_buffer + scan_duration / 2.0
     az_rad, el_rad = target.azel(timestamp=scan_mid_ts)
 
     # Convert RA/Dec parameters to azimuth using accurate elevation
     scan_width_az = scan_width_radec / np.cos(el_rad)
-    scan_speed_az = (scan_speed_radec / 60.0) / np.cos(el_rad)  # Convert arcmin/sec to deg/s
+    scan_speed_az = (scan_speed_radec / 60.0) / np.cos(el_rad)  # arcmin/s to deg/s
 
     # Create a new, temporary target fixed in Az/El for the scan.
     azel_target = katpoint.construct_azel_target(az_rad, el_rad)
@@ -214,9 +219,9 @@ def scan_const_el(session, target, nd_period=None, lead_time=None, **kwargs):
     end_az_offset = scan_width_az / 2.0
 
     # Log scan parameters for debugging and testing
-    user_logger.info("Scan duration is %.2f s and scan speed is %.2f deg/s", 
+    user_logger.info("Scan duration is %.2f s and scan speed is %.2f deg/s",
                      scan_duration, scan_speed_az)
-    user_logger.info("Azimuth scan extent [%.1f, %.1f]", 
+    user_logger.info("Azimuth scan extent [%.1f, %.1f]",
                      start_az_offset, end_az_offset)
 
     # Construct arguments for the underlying scan function.
@@ -233,14 +238,16 @@ def scan_const_el(session, target, nd_period=None, lead_time=None, **kwargs):
     user_logger.debug("DEBUG: Passing to session.scan: {}".format(scan_kwargs))
 
     # Call the generic scan function with the new Az/El target and calculated parameters
-    return scan(session, azel_target, nd_period=nd_period, lead_time=lead_time, **scan_kwargs)
+    return scan(
+        session, azel_target, nd_period=nd_period, lead_time=lead_time, **scan_kwargs
+    )
 
 
 def multi_scan_target_el(session, target, nd_period=None, lead_time=None, **kwargs):
     """Run multiple scan lines through a target.
 
-    This function performs multiple back-and-forth scan lines, with each scan line
-    going through the target position as it moves across the sky. Unlike multi_scan_const_el,
+    This function performs multiple back-and-forth scan lines, with each scan line going
+    through the target position as it moves across the sky. Unlike multi_scan_const_el,
     each scan line will be at a different elevation as the target moves.
 
     Parameters
@@ -258,7 +265,11 @@ def multi_scan_target_el(session, target, nd_period=None, lead_time=None, **kwar
     """
     required_params = ['scan_width_radec', 'scan_speed_radec', 'num_scan_lines']
     if not all(k in kwargs for k in required_params):
-        raise ValueError("Multi-scan target elevation requires {} in YAML config".format(required_params))
+        raise ValueError(
+            "Multi-scan target elevation requires {} in YAML config".format(
+                required_params
+            )
+        )
 
     # trigger noise diode if set
     trigger(session.kat, duration=nd_period, lead_time=lead_time)
@@ -267,7 +278,7 @@ def multi_scan_target_el(session, target, nd_period=None, lead_time=None, **kwar
     scan_width_radec = float(kwargs['scan_width_radec'])  # degrees in RA/Dec
     scan_speed_radec = float(kwargs['scan_speed_radec'])  # arcmin/sec in RA/Dec
     num_scan_lines = int(kwargs['num_scan_lines'])
-    
+
     # Basic validation
     if num_scan_lines == 0:
         user_logger.warning("Number of scan lines is zero")
@@ -289,21 +300,28 @@ def multi_scan_target_el(session, target, nd_period=None, lead_time=None, **kwar
     scan_start_buffer = 3.0  # seconds
     initial_scan_mid_ts = initial_timestamp + scan_start_buffer + scan_duration / 2.0
     az_rad_initial, el_rad_initial = target.azel(timestamp=initial_scan_mid_ts)
-    
+
     # Convert RA/Dec width to azimuth width for initial positioning
     scan_width_az_initial = scan_width_radec / np.cos(el_rad_initial)
-    
+
     # Pre-position telescope to first scan line start position
     start_az_offset_initial = -scan_width_az_initial / 2.0  # Always start west->east
-    start_az_rad_initial = katpoint.wrap_angle(az_rad_initial + np.radians(start_az_offset_initial))
-    
-    scan_start_target = katpoint.construct_azel_target(start_az_rad_initial, el_rad_initial)
+    start_az_rad_initial = katpoint.wrap_angle(
+        az_rad_initial + np.radians(start_az_offset_initial)
+    )
+
+    scan_start_target = katpoint.construct_azel_target(
+        start_az_rad_initial, el_rad_initial
+    )
     scan_start_target.name = target.name
     scan_start_target.antenna = target.antenna
-    
-    user_logger.info("Pre-positioning to first scan start (Az, El): ({:.2f}, {:.2f}) deg".format(
-        np.degrees(start_az_rad_initial), np.degrees(el_rad_initial)))
-    
+
+    user_logger.info(
+        "Pre-positioning to first scan start (Az, El): ({:.2f}, {:.2f}) deg".format(
+            np.degrees(start_az_rad_initial), np.degrees(el_rad_initial)
+        )
+    )
+
     target_visible = session.track(scan_start_target, duration=0.0, announce=False)
     if not target_visible:
         user_logger.warning("First scan start position not visible")
@@ -319,7 +337,7 @@ def multi_scan_target_el(session, target, nd_period=None, lead_time=None, **kwar
             current_timestamp = session.time
         except AttributeError:
             current_timestamp = time.time()
-        
+
         # Calculate target position at this scan's middle time
         scan_mid_ts = current_timestamp + scan_start_buffer + scan_duration / 2.0
         az_rad, el_rad = target.azel(timestamp=scan_mid_ts)
@@ -333,28 +351,33 @@ def multi_scan_target_el(session, target, nd_period=None, lead_time=None, **kwar
         azel_target.antenna = target.antenna
 
         # Calculate scan direction for this line
-        start_az_offset = -scan_width_az / 2.0 if not scan_direction else scan_width_az / 2.0
-        end_az_offset = scan_width_az / 2.0 if not scan_direction else -scan_width_az / 2.0
+        offset_size = scan_width_az / 2.0
+        start_az_offset = -offset_size if not scan_direction else offset_size
+        end_az_offset = offset_size if not scan_direction else -offset_size
 
         # Log scan line info
         direction_str = "East->West" if scan_direction else "West->East"
         user_logger.info("Scan line {}: {} at (Az, El): ({:.2f}, {:.2f}) deg".format(
             completed_scans + 1, direction_str, np.degrees(az_rad), np.degrees(el_rad)))
-        user_logger.info("Azimuth scan extent [%.1f, %.1f]", start_az_offset, end_az_offset)
+        user_logger.info(
+            "Azimuth scan extent [%.1f, %.1f]", start_az_offset, end_az_offset
+        )
 
         # Prepare scan parameters
         scan_kwargs = kwargs.copy()
         scan_kwargs['duration'] = scan_duration
         scan_kwargs['start'] = (start_az_offset, 0.0)
         scan_kwargs['end'] = (end_az_offset, 0.0)
-        
+
         # Clean up parameters not meant for core scan function
         for param in required_params:
             scan_kwargs.pop(param, None)
 
         # Execute the scan line
-        line_success = scan(session, azel_target, nd_period=nd_period, lead_time=lead_time, **scan_kwargs)
-        
+        line_success = scan(
+            session, azel_target, nd_period=nd_period, lead_time=lead_time, **scan_kwargs
+        )
+
         if line_success:
             completed_scans += 1
             scan_direction = not scan_direction  # Alternate direction for next scan
@@ -362,7 +385,9 @@ def multi_scan_target_el(session, target, nd_period=None, lead_time=None, **kwar
             user_logger.warning("Scan line {} failed".format(completed_scans + 1))
             break
 
-    user_logger.info("Multi-scan target completed - {} scan lines executed".format(completed_scans))
+    user_logger.info(
+        "Multi-scan target completed - {} scan lines executed".format(completed_scans)
+    )
     return completed_scans > 0
 
 
@@ -371,7 +396,8 @@ def multi_scan_const_el(session, target, nd_period=None, lead_time=None, **kwarg
 
     This function performs multiple back-and-forth scan lines at the same elevation
     while the target naturally drifts through the scan pattern due to sky rotation.
-    The target will cross the scan line once when its elevation matches the scan elevation.
+    The target will cross the scan line once when its elevation matches the scan
+    elevation.
 
     Parameters
     ----------
@@ -388,7 +414,11 @@ def multi_scan_const_el(session, target, nd_period=None, lead_time=None, **kwarg
     """
     required_params = ['obs_duration', 'scan_width_radec', 'scan_speed_radec']
     if not all(k in kwargs for k in required_params):
-        raise ValueError("Multi-scan constant elevation requires {} in YAML config".format(required_params))
+        raise ValueError(
+            "Multi-scan constant elevation requires {} in YAML config".format(
+                required_params
+            )
+        )
 
     # trigger noise diode if set
     trigger(session.kat, duration=nd_period, lead_time=lead_time)
@@ -406,21 +436,24 @@ def multi_scan_const_el(session, target, nd_period=None, lead_time=None, **kwarg
 
     # Calculate how many scan lines we can fit in the observation time
     num_scan_lines = round(obs_duration_sec / scan_line_duration)
-    
+
     # Basic validation
     if num_scan_lines == 0:
         user_logger.warning("Observation duration too short for any complete scan lines")
         return False
-    
+
     # Calculate total scan duration and slew times
     actual_obs_duration_sec = num_scan_lines * scan_line_duration
     actual_obs_duration_min = actual_obs_duration_sec / 60.0
     slew_time_per_scan = 3.2  # seconds
     scans_slew_time = (num_scan_lines - 1) * slew_time_per_scan
     total_scans_duration = actual_obs_duration_sec + scans_slew_time
-    
-    user_logger.info("Planning {} scan lines over {:.1f} minutes (requested: {:.1f} min)".format(
-        num_scan_lines, actual_obs_duration_min, obs_duration_min))
+
+    user_logger.info(
+        "Planning {} scan lines over {:.1f} minutes (requested: {:.1f} min)".format(
+            num_scan_lines, actual_obs_duration_min, obs_duration_min
+        )
+    )
 
     # Get current time from session if available, else use real time
     try:
@@ -439,15 +472,20 @@ def multi_scan_const_el(session, target, nd_period=None, lead_time=None, **kwarg
 
     # Pre-position telescope to first scan line start position
     initial_start_az_offset = -azimuth_width_deg / 2.0  # Always start west->east
-    initial_start_az_rad = katpoint.wrap_angle(az_mid_rad + np.radians(initial_start_az_offset))
-    
+    initial_start_az_rad = katpoint.wrap_angle(
+        az_mid_rad + np.radians(initial_start_az_offset)
+    )
+
     scan_start_target = katpoint.construct_azel_target(initial_start_az_rad, el_mid_rad)
     scan_start_target.name = target.name
     scan_start_target.antenna = target.antenna
-    
-    user_logger.info("Pre-positioning to first scan start (Az, El): ({:.2f}, {:.2f}) deg".format(
-        np.degrees(initial_start_az_rad), np.degrees(el_mid_rad)))
-    
+
+    user_logger.info(
+        "Pre-positioning to first scan start (Az, El): ({:.2f}, {:.2f}) deg".format(
+            np.degrees(initial_start_az_rad), np.degrees(el_mid_rad)
+        )
+    )
+
     target_visible = session.track(scan_start_target, duration=0.0, announce=False)
     if not target_visible:
         user_logger.warning("First scan start position not visible")
@@ -458,9 +496,10 @@ def multi_scan_const_el(session, target, nd_period=None, lead_time=None, **kwarg
         current_timestamp = session.time
     except AttributeError:
         current_timestamp = time.time()
-    
-    # Recalculate target at actual observation middle (including slew times). Add 3 sec slew time for good measure
-    obs_mid_timestamp_recalc = 3 + current_timestamp + total_scans_duration / 2.0
+
+    # Recalculate target at actual observation middle (including slew times).
+    # Add 3 sec slew time for good measure.
+    obs_mid_timestamp_recalc = 3.0 + current_timestamp + total_scans_duration / 2.0
     az_mid_recalc, el_mid_recalc = target.azel(timestamp=obs_mid_timestamp_recalc)
 
     user_logger.info("Target at obs middle (Az, El): ({:.2f}, {:.2f}) deg".format(
@@ -471,9 +510,13 @@ def multi_scan_const_el(session, target, nd_period=None, lead_time=None, **kwarg
 
     # Convert RA/Dec speed to azimuth speed (arcmin/sec -> deg/s)
     azimuth_speed_deg_per_sec = (scan_speed_radec / 60.0) / np.cos(el_mid_recalc)
-    
-    user_logger.info("Converted scan width: {:.2f} deg in azimuth".format(azimuth_width_deg))
-    user_logger.info("Converted scan speed: {:.2f} deg/s in azimuth".format(azimuth_speed_deg_per_sec))    
+
+    user_logger.info(
+        "Converted scan width: {:.2f} deg in azimuth".format(azimuth_width_deg)
+    )
+    user_logger.info(
+        "Converted scan speed: {:.2f} deg/s in azimuth".format(azimuth_speed_deg_per_sec)
+    )
 
     # Create fixed Az/El target for all scan lines using recalculated position
     azel_target = katpoint.construct_azel_target(az_mid_recalc, el_mid_recalc)
@@ -486,14 +529,23 @@ def multi_scan_const_el(session, target, nd_period=None, lead_time=None, **kwarg
 
     while completed_scans < num_scan_lines:
         # Calculate scan direction for this line
-        start_az_offset = -azimuth_width_deg / 2.0 if not scan_direction else azimuth_width_deg / 2.0
-        end_az_offset = azimuth_width_deg / 2.0 if not scan_direction else -azimuth_width_deg / 2.0
+        offset_size = azimuth_width_deg / 2.0
+        start_az_offset = -offset_size if not scan_direction else offset_size
+        end_az_offset = offset_size if not scan_direction else -offset_size
 
         # Log scan line info
         direction_str = "East->West" if scan_direction else "West->East"
-        user_logger.info("Scan line {}: {} at (Az, El): ({:.2f}, {:.2f}) deg".format(
-            completed_scans + 1, direction_str, np.degrees(az_mid_recalc), np.degrees(el_mid_recalc)))
-        user_logger.info("Azimuth scan extent [%.1f, %.1f]", start_az_offset, end_az_offset)
+        user_logger.info(
+            "Scan line {}: {} at (Az, El): ({:.2f}, {:.2f}) deg".format(
+                completed_scans + 1,
+                direction_str,
+                np.degrees(az_mid_recalc),
+                np.degrees(el_mid_recalc),
+            )
+        )
+        user_logger.info(
+            "Azimuth scan extent [%.1f, %.1f]", start_az_offset, end_az_offset
+        )
 
         # Prepare scan parameters
         scan_kwargs = kwargs.copy()
@@ -501,14 +553,16 @@ def multi_scan_const_el(session, target, nd_period=None, lead_time=None, **kwarg
         scan_kwargs['duration'] = scan_line_duration
         scan_kwargs['start'] = (start_az_offset, 0.0)
         scan_kwargs['end'] = (end_az_offset, 0.0)
-        
+
         # Clean up parameters not meant for core scan function
         for param in required_params:
             scan_kwargs.pop(param, None)
 
         # Execute the scan line
-        line_success = scan(session, azel_target, nd_period=nd_period, lead_time=lead_time, **scan_kwargs)
-        
+        line_success = scan(
+            session, azel_target, nd_period=nd_period, lead_time=lead_time, **scan_kwargs
+        )
+
         if line_success:
             completed_scans += 1
             scan_direction = not scan_direction  # Alternate direction for next scan
@@ -516,7 +570,9 @@ def multi_scan_const_el(session, target, nd_period=None, lead_time=None, **kwarg
             user_logger.warning("Scan line {} failed".format(completed_scans + 1))
             break
 
-    user_logger.info("Multi-scan completed - {} scan lines executed".format(completed_scans))
+    user_logger.info(
+        "Multi-scan completed - {} scan lines executed".format(completed_scans)
+    )
     return completed_scans > 0
 
 

--- a/astrokat/scans.py
+++ b/astrokat/scans.py
@@ -223,6 +223,7 @@ def scan_const_el(session, target, nd_period=None, lead_time=None, **kwargs):
     # Start with a copy of the input kwargs to preserve other scan options
     # like 'projection' from the YAML file.
     scan_kwargs = kwargs.copy()
+    scan_kwargs['projection'] = scan_kwargs.get('projection', 'plate-carree')
     scan_kwargs['duration'] = scan_duration
     scan_kwargs['start'] = (start_az_offset, 0.0)  # (az_offset, el_offset)
     scan_kwargs['end'] = (end_az_offset, 0.0)
@@ -496,6 +497,7 @@ def multi_scan_const_el(session, target, nd_period=None, lead_time=None, **kwarg
 
         # Prepare scan parameters
         scan_kwargs = kwargs.copy()
+        scan_kwargs['projection'] = scan_kwargs.get('projection', 'plate-carree')
         scan_kwargs['duration'] = scan_line_duration
         scan_kwargs['start'] = (start_az_offset, 0.0)
         scan_kwargs['end'] = (end_az_offset, 0.0)

--- a/astrokat/scans.py
+++ b/astrokat/scans.py
@@ -144,7 +144,7 @@ def scan_const_el(session, target, nd_period=None, lead_time=None, **kwargs):
     """
     required_params = ['scan_width_radec', 'scan_speed_radec']
     if not all(k in kwargs for k in required_params):
-        raise ValueError(f"Constant elevation scan requires {required_params} in YAML config")
+        raise ValueError("Constant elevation scan requires {} in YAML config".format(required_params))
 
     # trigger noise diode if set
     trigger(session.kat, duration=nd_period, lead_time=lead_time)
@@ -257,7 +257,7 @@ def multi_scan_target_el(session, target, nd_period=None, lead_time=None, **kwar
     """
     required_params = ['scan_width_radec', 'scan_speed_radec', 'num_scan_lines']
     if not all(k in kwargs for k in required_params):
-        raise ValueError(f"Multi-scan target elevation requires {required_params} in YAML config")
+        raise ValueError("Multi-scan target elevation requires {} in YAML config".format(required_params))
 
     # trigger noise diode if set
     trigger(session.kat, duration=nd_period, lead_time=lead_time)
@@ -387,7 +387,7 @@ def multi_scan_const_el(session, target, nd_period=None, lead_time=None, **kwarg
     """
     required_params = ['obs_duration', 'scan_width_radec', 'scan_speed_radec']
     if not all(k in kwargs for k in required_params):
-        raise ValueError(f"Multi-scan constant elevation requires {required_params} in YAML config")
+        raise ValueError("Multi-scan constant elevation requires {} in YAML config".format(required_params))
 
     # trigger noise diode if set
     trigger(session.kat, duration=nd_period, lead_time=lead_time)

--- a/astrokat/scans.py
+++ b/astrokat/scans.py
@@ -121,6 +121,404 @@ def scan(session, target, nd_period=None, lead_time=None, **kwargs):
     return session.scan(target, **kwargs)
 
 
+def scan_const_el(session, target, nd_period=None, lead_time=None, **kwargs):
+    """Run a scan at a constant elevation.
+
+    This is achieved by defining the scan in horizontal (azimuth-elevation)
+    coordinates. The center of the scan is the azimuth and elevation of the
+    celestial target at the start of the scan. This function reuses the
+    generic `scan()` function to perform the telescope movement.
+
+    Parameters
+    ----------
+    session: `CaptureSession`
+    target: katpoint.Target
+        The celestial target (e.g., in RA/Dec) to center the scan on.
+    nd_period: float
+        noisediode period
+    lead_time: float
+        noisediode trigger lead time
+    **kwargs: dict
+        Must contain 'scan_width_radec' (in degrees) and
+        'scan_speed_radec' (in arcmin/sec).
+    """
+    required_params = ['scan_width_radec', 'scan_speed_radec']
+    if not all(k in kwargs for k in required_params):
+        raise ValueError(f"Constant elevation scan requires {required_params} in YAML config")
+
+    # trigger noise diode if set
+    trigger(session.kat, duration=nd_period, lead_time=lead_time)
+
+    scan_width_radec = float(kwargs['scan_width_radec'])  # degrees in RA/Dec
+    scan_speed_radec = float(kwargs['scan_speed_radec'])  # arcmin/sec in RA/Dec
+    
+    # Calculate scan duration in seconds (no elevation conversion needed)
+    scan_duration = scan_width_radec / scan_speed_radec * 60
+
+    # Get current time from session if available, else use real time
+    try:
+        timestamp = session.time
+    except AttributeError:
+        timestamp = time.time()
+
+    # Try to figure out the target position in az, el
+    # Add buffer to account for scan setup delays before telescope starts scanning
+    scan_start_buffer = 3.0  # seconds
+    scan_mid_ts = timestamp + scan_start_buffer + scan_duration / 2.0
+    az_rad, el_rad = target.azel(timestamp=scan_mid_ts)
+        
+    # Convert RA/Dec width to azimuth width for initial positioning (rough estimate)
+    scan_width_az_initial = scan_width_radec / np.cos(el_rad)
+    
+    # Calculate scan start position (offset from center)
+    start_az_offset = -scan_width_az_initial / 2.0
+    start_az_rad = katpoint.wrap_angle(az_rad + np.radians(start_az_offset))
+    
+    # Create target at scan start position for pre-positioning
+    scan_start_target = katpoint.construct_azel_target(start_az_rad, el_rad)
+    scan_start_target.name = target.name
+    scan_start_target.antenna = target.antenna
+    
+    user_logger.info("Pre-positioning to scan start (Az, El): ({:.2f}, {:.2f}) deg".format(
+        np.degrees(start_az_rad), np.degrees(el_rad)))
+    
+    # Pre-position telescope to scan start with minimal slewing during scan
+    target_visible = session.track(scan_start_target, duration=0.0, announce=False)
+    if not target_visible:
+        user_logger.warning("Scan start position not visible")
+        return False
+    
+    # After slewing, recalculate target position at scan center for actual scan
+    try:
+        current_timestamp = session.time
+    except AttributeError:
+        current_timestamp = time.time()
+    
+    scan_mid_ts = current_timestamp + scan_start_buffer + scan_duration / 2.0
+    az_rad, el_rad = target.azel(timestamp=scan_mid_ts)
+
+    # Convert RA/Dec parameters to azimuth using accurate elevation
+    scan_width_az = scan_width_radec / np.cos(el_rad)
+    scan_speed_az = (scan_speed_radec / 60.0) / np.cos(el_rad)  # Convert arcmin/sec to deg/s
+
+    # Create a new, temporary target fixed in Az/El for the scan.
+    azel_target = katpoint.construct_azel_target(az_rad, el_rad)
+    azel_target.name = target.name  # Keep the original name for logging
+    azel_target.antenna = target.antenna  # Ensure observer is consistent
+
+    user_logger.info("Scan center (Az, El): ({:.2f}, {:.2f}) deg".format(
+        np.degrees(az_rad), np.degrees(el_rad)))
+
+    # Calculate scan parameters for the session.scan() call using accurate azimuth width
+    start_az_offset = -scan_width_az / 2.0
+    end_az_offset = scan_width_az / 2.0
+
+    # Log scan parameters for debugging and testing
+    user_logger.info("Scan duration is %.2f s and scan speed is %.2f deg/s", 
+                     scan_duration, scan_speed_az)
+    user_logger.info("Azimuth scan extent [%.1f, %.1f]", 
+                     start_az_offset, end_az_offset)
+
+    # Construct arguments for the underlying scan function.
+    # Start with a copy of the input kwargs to preserve other scan options
+    # like 'projection' from the YAML file.
+    scan_kwargs = kwargs.copy()
+    scan_kwargs['duration'] = scan_duration
+    scan_kwargs['start'] = (start_az_offset, 0.0)  # (az_offset, el_offset)
+    scan_kwargs['end'] = (end_az_offset, 0.0)
+    # Clean up keys that are not meant for the core scan function
+    for param in required_params:
+        scan_kwargs.pop(param, None)
+    user_logger.debug("DEBUG: Passing to session.scan: {}".format(scan_kwargs))
+
+    # Call the generic scan function with the new Az/El target and calculated parameters
+    return scan(session, azel_target, nd_period=nd_period, lead_time=lead_time, **scan_kwargs)
+
+
+def multi_scan_target_el(session, target, nd_period=None, lead_time=None, **kwargs):
+    """Run multiple scan lines through a target.
+
+    This function performs multiple back-and-forth scan lines, with each scan line
+    going through the target position as it moves across the sky. Unlike multi_scan_const_el,
+    each scan line will be at a different elevation as the target moves.
+
+    Parameters
+    ----------
+    session: `CaptureSession`
+    target: katpoint.Target
+        The celestial target (in RA/Dec) to observe.
+    nd_period: float
+        noisediode period
+    lead_time: float
+        noisediode trigger lead time
+    **kwargs: dict
+        Must contain 'scan_width_radec' (in degrees), 'scan_speed_radec' (in arcmin/sec),
+        and 'num_scan_lines' (integer).
+    """
+    required_params = ['scan_width_radec', 'scan_speed_radec', 'num_scan_lines']
+    if not all(k in kwargs for k in required_params):
+        raise ValueError(f"Multi-scan target elevation requires {required_params} in YAML config")
+
+    # trigger noise diode if set
+    trigger(session.kat, duration=nd_period, lead_time=lead_time)
+
+    # Extract parameters
+    scan_width_radec = float(kwargs['scan_width_radec'])  # degrees in RA/Dec
+    scan_speed_radec = float(kwargs['scan_speed_radec'])  # arcmin/sec in RA/Dec
+    num_scan_lines = int(kwargs['num_scan_lines'])
+    
+    # Basic validation
+    if num_scan_lines == 0:
+        user_logger.warning("Number of scan lines is zero")
+        return False
+
+    # Calculate scan duration in seconds (no elevation conversion needed)
+    scan_duration = scan_width_radec / scan_speed_radec * 60
+
+    user_logger.info("Planning {} scan lines through target".format(num_scan_lines))
+    user_logger.info("Individual scan line duration: {:.2f} s".format(scan_duration))
+
+    # Get current time for initial positioning
+    try:
+        initial_timestamp = session.time
+    except AttributeError:
+        initial_timestamp = time.time()
+
+    # Calculate initial target position for first scan pre-positioning
+    scan_start_buffer = 3.0  # seconds
+    initial_scan_mid_ts = initial_timestamp + scan_start_buffer + scan_duration / 2.0
+    az_rad_initial, el_rad_initial = target.azel(timestamp=initial_scan_mid_ts)
+    
+    # Convert RA/Dec width to azimuth width for initial positioning
+    scan_width_az_initial = scan_width_radec / np.cos(el_rad_initial)
+    
+    # Pre-position telescope to first scan line start position
+    start_az_offset_initial = -scan_width_az_initial / 2.0  # Always start west->east
+    start_az_rad_initial = katpoint.wrap_angle(az_rad_initial + np.radians(start_az_offset_initial))
+    
+    scan_start_target = katpoint.construct_azel_target(start_az_rad_initial, el_rad_initial)
+    scan_start_target.name = target.name
+    scan_start_target.antenna = target.antenna
+    
+    user_logger.info("Pre-positioning to first scan start (Az, El): ({:.2f}, {:.2f}) deg".format(
+        np.degrees(start_az_rad_initial), np.degrees(el_rad_initial)))
+    
+    target_visible = session.track(scan_start_target, duration=0.0, announce=False)
+    if not target_visible:
+        user_logger.warning("First scan start position not visible")
+        return False
+
+    # Start multi-scan observation
+    scan_direction = False  # Start with west->east
+    completed_scans = 0
+
+    while completed_scans < num_scan_lines:
+        # Recalculate target position for this scan line (target is moving!)
+        try:
+            current_timestamp = session.time
+        except AttributeError:
+            current_timestamp = time.time()
+        
+        # Calculate target position at this scan's middle time
+        scan_mid_ts = current_timestamp + scan_start_buffer + scan_duration / 2.0
+        az_rad, el_rad = target.azel(timestamp=scan_mid_ts)
+
+        # Convert RA/Dec parameters to azimuth using current elevation
+        scan_width_az = scan_width_radec / np.cos(el_rad)
+
+        # Create fixed Az/El target for this scan line
+        azel_target = katpoint.construct_azel_target(az_rad, el_rad)
+        azel_target.name = target.name
+        azel_target.antenna = target.antenna
+
+        # Calculate scan direction for this line
+        start_az_offset = -scan_width_az / 2.0 if not scan_direction else scan_width_az / 2.0
+        end_az_offset = scan_width_az / 2.0 if not scan_direction else -scan_width_az / 2.0
+
+        # Log scan line info
+        direction_str = "East->West" if scan_direction else "West->East"
+        user_logger.info("Scan line {}: {} at (Az, El): ({:.2f}, {:.2f}) deg".format(
+            completed_scans + 1, direction_str, np.degrees(az_rad), np.degrees(el_rad)))
+        user_logger.info("Azimuth scan extent [%.1f, %.1f]", start_az_offset, end_az_offset)
+
+        # Prepare scan parameters
+        scan_kwargs = kwargs.copy()
+        scan_kwargs['duration'] = scan_duration
+        scan_kwargs['start'] = (start_az_offset, 0.0)
+        scan_kwargs['end'] = (end_az_offset, 0.0)
+        
+        # Clean up parameters not meant for core scan function
+        for param in required_params:
+            scan_kwargs.pop(param, None)
+
+        # Execute the scan line
+        line_success = scan(session, azel_target, nd_period=nd_period, lead_time=lead_time, **scan_kwargs)
+        
+        if line_success:
+            completed_scans += 1
+            scan_direction = not scan_direction  # Alternate direction for next scan
+        else:
+            user_logger.warning("Scan line {} failed".format(completed_scans + 1))
+            break
+
+    user_logger.info("Multi-scan target completed - {} scan lines executed".format(completed_scans))
+    return completed_scans > 0
+
+
+def multi_scan_const_el(session, target, nd_period=None, lead_time=None, **kwargs):
+    """Run multiple scan lines at a constant elevation.
+
+    This function performs multiple back-and-forth scan lines at the same elevation
+    while the target naturally drifts through the scan pattern due to sky rotation.
+    The target will cross the scan line once when its elevation matches the scan elevation.
+
+    Parameters
+    ----------
+    session: `CaptureSession`
+    target: katpoint.Target
+        The celestial target (in RA/Dec) to observe.
+    nd_period: float
+        noisediode period
+    lead_time: float
+        noisediode trigger lead time
+    **kwargs: dict
+        Must contain 'obs_duration' (in minutes), 'scan_width_radec' (in degrees),
+        and 'scan_speed_radec' (in arcmin/sec).
+    """
+    required_params = ['obs_duration', 'scan_width_radec', 'scan_speed_radec']
+    if not all(k in kwargs for k in required_params):
+        raise ValueError(f"Multi-scan constant elevation requires {required_params} in YAML config")
+
+    # trigger noise diode if set
+    trigger(session.kat, duration=nd_period, lead_time=lead_time)
+
+    # Extract parameters
+    obs_duration_min = float(kwargs['obs_duration'])
+    scan_width_radec = float(kwargs['scan_width_radec'])  # degrees in RA/Dec
+    scan_speed_radec = float(kwargs['scan_speed_radec'])  # arcmin/sec in RA/Dec
+
+    obs_duration_sec = obs_duration_min * 60.0
+
+    # Calculate scan line duration in seconds
+    scan_line_duration = scan_width_radec / scan_speed_radec * 60
+    user_logger.info("Individual scan line duration: {:.2f} s".format(scan_line_duration))
+
+    # Calculate how many scan lines we can fit in the observation time
+    num_scan_lines = round(obs_duration_sec / scan_line_duration)
+    
+    # Basic validation
+    if num_scan_lines == 0:
+        user_logger.warning("Observation duration too short for any complete scan lines")
+        return False
+    
+    # Calculate total scan duration and slew times
+    actual_obs_duration_sec = num_scan_lines * scan_line_duration
+    actual_obs_duration_min = actual_obs_duration_sec / 60.0
+    slew_time_per_scan = 3.2  # seconds
+    scans_slew_time = (num_scan_lines - 1) * slew_time_per_scan
+    total_scans_duration = actual_obs_duration_sec + scans_slew_time
+    
+    user_logger.info("Planning {} scan lines over {:.1f} minutes (requested: {:.1f} min)".format(
+        num_scan_lines, actual_obs_duration_min, obs_duration_min))
+
+    # Get current time from session if available, else use real time
+    try:
+        obs_start_timestamp = session.time
+    except AttributeError:
+        obs_start_timestamp = time.time()
+
+    # First guess at calculating target position in az,el at middle of observation
+    # add a 20 sec slew buffer for good measure
+    obs_mid_timestamp = 20 + obs_start_timestamp + total_scans_duration / 2.0
+    az_mid_rad, el_mid_rad = target.azel(timestamp=obs_mid_timestamp)
+
+    # Convert RA/Dec width to azimuth width using first elevation guess
+    # At high elevation, cos(el) -> 0, requiring large azimuth width
+    azimuth_width_deg = scan_width_radec / np.cos(el_mid_rad)
+
+    # Pre-position telescope to first scan line start position
+    initial_start_az_offset = -azimuth_width_deg / 2.0  # Always start west->east
+    initial_start_az_rad = katpoint.wrap_angle(az_mid_rad + np.radians(initial_start_az_offset))
+    
+    scan_start_target = katpoint.construct_azel_target(initial_start_az_rad, el_mid_rad)
+    scan_start_target.name = target.name
+    scan_start_target.antenna = target.antenna
+    
+    user_logger.info("Pre-positioning to first scan start (Az, El): ({:.2f}, {:.2f}) deg".format(
+        np.degrees(initial_start_az_rad), np.degrees(el_mid_rad)))
+    
+    target_visible = session.track(scan_start_target, duration=0.0, announce=False)
+    if not target_visible:
+        user_logger.warning("First scan start position not visible")
+        return False
+
+    # After slewing, recalculate target position at observation middle for all scan lines
+    try:
+        current_timestamp = session.time
+    except AttributeError:
+        current_timestamp = time.time()
+    
+    # Recalculate target at actual observation middle (including slew times). Add 3 sec slew time for good measure
+    obs_mid_timestamp_recalc = 3 + current_timestamp + total_scans_duration / 2.0
+    az_mid_recalc, el_mid_recalc = target.azel(timestamp=obs_mid_timestamp_recalc)
+
+    user_logger.info("Target at obs middle (Az, El): ({:.2f}, {:.2f}) deg".format(
+        np.degrees(az_mid_recalc), np.degrees(el_mid_recalc)))
+
+    # Convert RA/Dec width to azimuth width using final elevation
+    azimuth_width_deg = scan_width_radec / np.cos(el_mid_recalc)
+
+    # Convert RA/Dec speed to azimuth speed (arcmin/sec -> deg/s)
+    azimuth_speed_deg_per_sec = (scan_speed_radec / 60.0) / np.cos(el_mid_recalc)
+    
+    user_logger.info("Converted scan width: {:.2f} deg in azimuth".format(azimuth_width_deg))
+    user_logger.info("Converted scan speed: {:.2f} deg/s in azimuth".format(azimuth_speed_deg_per_sec))    
+
+    # Create fixed Az/El target for all scan lines using recalculated position
+    azel_target = katpoint.construct_azel_target(az_mid_recalc, el_mid_recalc)
+    azel_target.name = target.name
+    azel_target.antenna = target.antenna
+
+    # Start multi-scan observation
+    scan_direction = False  # Start with west->east (like reversescan)
+    completed_scans = 0
+
+    while completed_scans < num_scan_lines:
+        # Calculate scan direction for this line
+        start_az_offset = -azimuth_width_deg / 2.0 if not scan_direction else azimuth_width_deg / 2.0
+        end_az_offset = azimuth_width_deg / 2.0 if not scan_direction else -azimuth_width_deg / 2.0
+
+        # Log scan line info
+        direction_str = "East->West" if scan_direction else "West->East"
+        user_logger.info("Scan line {}: {} at (Az, El): ({:.2f}, {:.2f}) deg".format(
+            completed_scans + 1, direction_str, np.degrees(az_mid_recalc), np.degrees(el_mid_recalc)))
+        user_logger.info("Azimuth scan extent [%.1f, %.1f]", start_az_offset, end_az_offset)
+
+        # Prepare scan parameters
+        scan_kwargs = kwargs.copy()
+        scan_kwargs['duration'] = scan_line_duration
+        scan_kwargs['start'] = (start_az_offset, 0.0)
+        scan_kwargs['end'] = (end_az_offset, 0.0)
+        
+        # Clean up parameters not meant for core scan function
+        for param in required_params:
+            scan_kwargs.pop(param, None)
+
+        # Execute the scan line
+        line_success = scan(session, azel_target, nd_period=nd_period, lead_time=lead_time, **scan_kwargs)
+        
+        if line_success:
+            completed_scans += 1
+            scan_direction = not scan_direction  # Alternate direction for next scan
+        else:
+            user_logger.warning("Scan line {} failed".format(completed_scans + 1))
+            break
+
+    user_logger.info("Multi-scan completed - {} scan lines executed".format(completed_scans))
+    return completed_scans > 0
+
+
+
 def reference_pointing_scan(session, target, nd_period=None, lead_time=None, **kwargs):
     """Perform offset pointings on nearest pointing calibrator.
 

--- a/astrokat/test/test_scans.py
+++ b/astrokat/test/test_scans.py
@@ -117,19 +117,21 @@ class TestAstrokatYAML(unittest.TestCase):
         execute_observe_main("test_scans/scan-const-el-sim-test.yaml")
         # Verify the log output to confirm correct execution
         result = LoggedTelescope.user_logger_stream.getvalue()
-        
+
         # Check that scan center coordinates were calculated and logged
         self.assertIn("Scan center (Az, El):", result)
-        
-        # Check scan parameters (with current YAML: scan_width_radec=4.0, scan_speed_radec=4.0)
-        # Converted to azimuth at ~56° elevation: width≈7.2°, speed≈0.12 deg/s, extent≈[-3.6, 3.6]
+
+        # Check scan parameters
+        # (with current YAML: scan_width_radec=4.0, scan_speed_radec=4.0)
+        # Converted to azimuth at ~56° elevation:
+        # width≈7.2°, speed≈0.12 deg/s, extent≈[-3.6, 3.6]
         self.assertIn("scan speed is 0.12 deg/s", result)
         self.assertIn("Azimuth scan extent [-3.6, 3.6]", result)
-        
+
         # Check that the scan was executed (converted to azel target)
         self.assertIn("Scan target: PictorA, tags=azel", result)
-        
-        # Check that the target was slewed to 
+
+        # Check that the target was slewed to
         self.assertIn("Slewed to PictorA at azel", result)
 
     def test_multi_scan_target_el_sim(self):
@@ -140,27 +142,27 @@ class TestAstrokatYAML(unittest.TestCase):
         execute_observe_main("test_scans/multi_scan_target_el.yaml")
         # Verify the log output to confirm correct execution
         result = LoggedTelescope.user_logger_stream.getvalue()
-        
+
         # Check that multiple scan lines were planned
         self.assertIn("Planning 10 scan lines through target", result)
-        
+
         # Check that individual scan duration was logged
         self.assertIn("Individual scan line duration:", result)
-        
+
         # Check that pre-positioning occurred
         self.assertIn("Pre-positioning to first scan start", result)
-        
+
         # Check that multiple scan lines were executed with alternating directions
         self.assertIn("Scan line 1: West->East", result)
         self.assertIn("Scan line 2: East->West", result)
         self.assertIn("Scan line 3: West->East", result)
-        
+
         # Check that scan completion was logged
         self.assertIn("Multi-scan target completed", result)
-        
+
         # Check that scans were executed (converted to azel targets)
         self.assertIn("Scan target: PictorA, tags=azel", result)
-        
+
         # Check that the target was slewed to
         self.assertIn("Slewed to PictorA at azel", result)
 
@@ -172,31 +174,31 @@ class TestAstrokatYAML(unittest.TestCase):
         execute_observe_main("test_scans/multi_scan_const_el.yaml")
         # Verify the log output to confirm correct execution
         result = LoggedTelescope.user_logger_stream.getvalue()
-        
+
         # Check that scan planning occurred with duration information
         self.assertIn("Planning", result)
         self.assertIn("scan lines over", result)
-        
+
         # Check that target position calculation was logged
         self.assertIn("Target at obs middle (Az, El):", result)
-        
+
         # Check that coordinate conversion was logged
         self.assertIn("Converted scan width:", result)
         self.assertIn("deg in azimuth", result)
-        
+
         # Check that pre-positioning occurred
         self.assertIn("Pre-positioning to first scan start", result)
-        
+
         # Check that multiple scan lines were executed with alternating directions
         self.assertIn("Scan line 1: West->East", result)
         self.assertIn("Scan line 2: East->West", result)
-        
+
         # Check that scan completion was logged
         self.assertIn("Multi-scan completed", result)
-        
+
         # Check that scans were executed (converted to azel targets)
         self.assertIn("Scan target: PictorA, tags=azel", result)
-        
+
         # Check that the target was slewed to
         self.assertIn("Slewed to PictorA at azel", result)
 

--- a/astrokat/test/test_scans.py
+++ b/astrokat/test/test_scans.py
@@ -109,6 +109,97 @@ class TestAstrokatYAML(unittest.TestCase):
         self.assertIn("Scan completed - 48 scan lines", result)
         self.assertEqual(result.count('Scan target: scan_azel_with_nd_trigger,'), 48)
 
+    def test_scan_const_el_sim(self):
+        """
+        Test that `scan_const_el` is correctly called and executed
+        from a YAML file in a simulated environment.
+        """
+        execute_observe_main("test_scans/scan-const-el-sim-test.yaml")
+        # Verify the log output to confirm correct execution
+        result = LoggedTelescope.user_logger_stream.getvalue()
+        
+        # Check that scan center coordinates were calculated and logged
+        self.assertIn("Scan center (Az, El):", result)
+        
+        # Check scan parameters (with current YAML: scan_width_radec=4.0, scan_speed_radec=4.0)
+        # Converted to azimuth at ~56° elevation: width≈7.2°, speed≈0.12 deg/s, extent≈[-3.6, 3.6]
+        self.assertIn("scan speed is 0.12 deg/s", result)
+        self.assertIn("Azimuth scan extent [-3.6, 3.6]", result)
+        
+        # Check that the scan was executed (converted to azel target)
+        self.assertIn("Scan target: PictorA, tags=azel", result)
+        
+        # Check that the target was slewed to 
+        self.assertIn("Slewed to PictorA at azel", result)
+
+    def test_multi_scan_target_el_sim(self):
+        """
+        Test that `multi_scan_target_el` is correctly called and executed
+        from a YAML file in a simulated environment.
+        """
+        execute_observe_main("test_scans/multi_scan_target_el.yaml")
+        # Verify the log output to confirm correct execution
+        result = LoggedTelescope.user_logger_stream.getvalue()
+        
+        # Check that multiple scan lines were planned
+        self.assertIn("Planning 10 scan lines through target", result)
+        
+        # Check that individual scan duration was logged
+        self.assertIn("Individual scan line duration:", result)
+        
+        # Check that pre-positioning occurred
+        self.assertIn("Pre-positioning to first scan start", result)
+        
+        # Check that multiple scan lines were executed with alternating directions
+        self.assertIn("Scan line 1: West->East", result)
+        self.assertIn("Scan line 2: East->West", result)
+        self.assertIn("Scan line 3: West->East", result)
+        
+        # Check that scan completion was logged
+        self.assertIn("Multi-scan target completed", result)
+        
+        # Check that scans were executed (converted to azel targets)
+        self.assertIn("Scan target: PictorA, tags=azel", result)
+        
+        # Check that the target was slewed to
+        self.assertIn("Slewed to PictorA at azel", result)
+
+    def test_multi_scan_const_el_sim(self):
+        """
+        Test that `multi_scan_const_el` is correctly called and executed
+        from a YAML file in a simulated environment.
+        """
+        execute_observe_main("test_scans/multi_scan_const_el.yaml")
+        # Verify the log output to confirm correct execution
+        result = LoggedTelescope.user_logger_stream.getvalue()
+        
+        # Check that scan planning occurred with duration information
+        self.assertIn("Planning", result)
+        self.assertIn("scan lines over", result)
+        
+        # Check that target position calculation was logged
+        self.assertIn("Target at obs middle (Az, El):", result)
+        
+        # Check that coordinate conversion was logged
+        self.assertIn("Converted scan width:", result)
+        self.assertIn("deg in azimuth", result)
+        
+        # Check that pre-positioning occurred
+        self.assertIn("Pre-positioning to first scan start", result)
+        
+        # Check that multiple scan lines were executed with alternating directions
+        self.assertIn("Scan line 1: West->East", result)
+        self.assertIn("Scan line 2: East->West", result)
+        
+        # Check that scan completion was logged
+        self.assertIn("Multi-scan completed", result)
+        
+        # Check that scans were executed (converted to azel targets)
+        self.assertIn("Scan target: PictorA, tags=azel", result)
+        
+        # Check that the target was slewed to
+        self.assertIn("Slewed to PictorA at azel", result)
+
     def assert_started_target_track(self, target_string, duration, result):
         simulate_message = "Slewed to {} at azel".format(target_string)
         katcorelib_message = "Initiating {:g}-second track on target {!r}".format(

--- a/astrokat/test/test_scans.py
+++ b/astrokat/test/test_scans.py
@@ -123,8 +123,8 @@ class TestAstrokatYAML(unittest.TestCase):
 
         # Check scan parameters
         # (with current YAML: scan_width_radec=4.0, scan_speed_radec=4.0)
-        # Converted to azimuth at ~56° elevation:
-        # width≈7.2°, speed≈0.12 deg/s, extent≈[-3.6, 3.6]
+        # Converted to azimuth at ~56 deg elevation:
+        # width ~7.2 deg, speed ~0.12 deg/s, extent ~ [-3.6, 3.6]
         self.assertIn("scan speed is 0.12 deg/s", result)
         self.assertIn("Azimuth scan extent [-3.6, 3.6]", result)
 

--- a/astrokat/test/test_scans/multi_scan_const_el.yaml
+++ b/astrokat/test/test_scans/multi_scan_const_el.yaml
@@ -1,0 +1,22 @@
+
+instrument:
+  integration_time: 2
+
+noise_diode:
+  antennas: all
+  cycle_len: 20.
+  on_frac: 0.015
+  lead_time: 12.
+
+durations:
+  start_time: 2025-08-23 03:10:00
+
+scan:
+  obs_duration: 10.0        # 10 minutes total observation
+  scan_width_radec: 4.0     # width in RA/Dec coordinate system in degrees
+  scan_speed_radec: 4.0     # arcmin/sec scanning speed in RA/Dec
+
+observation_loop:
+  - LST: 0:10-23:50
+    target_list:
+      - name=PictorA, radec=5:19:49.721 -45:46:43.7801, tags=target, type=multi_scan_const_el, duration=0.0

--- a/astrokat/test/test_scans/multi_scan_target_el.yaml
+++ b/astrokat/test/test_scans/multi_scan_target_el.yaml
@@ -1,0 +1,21 @@
+instrument:
+  integration_time: 2
+
+noise_diode:
+  antennas: all
+  cycle_len: 20.
+  on_frac: 0.015
+  lead_time: 12.
+
+durations:
+  start_time: 2025-08-23 03:10:00
+
+scan:
+  scan_width_radec: 4.0     # 1 degree width in RA/Dec coordinate system
+  scan_speed_radec: 4.0     # 2 arcmin/sec scanning speed in RA/Dec
+  num_scan_lines: 10         # Number of scan lines through target
+
+observation_loop:
+  - LST: 0:10-23:50
+    target_list:
+      - name=PictorA, radec=5:19:49.721 -45:46:43.7801, tags=target, type=multi_scan_target_el, duration=0.0

--- a/astrokat/test/test_scans/scan-const-el-sim-test.yaml
+++ b/astrokat/test/test_scans/scan-const-el-sim-test.yaml
@@ -1,0 +1,20 @@
+instrument:
+  integration_time: 2
+
+noise_diode:
+  antennas: all
+  cycle_len: 20.
+  on_frac: 0.015
+  lead_time: 12.
+
+durations:
+  start_time: 2025-08-23 03:10:00
+
+scan:
+  scan_width_radec: 4.0     # width in RA/Dec coordinate system in degrees
+  scan_speed_radec: 4.0     # arcmin/sec scanning speed in RA/Dec
+
+observation_loop:
+  - LST: 0:10-23:50
+    target_list:
+      - name=PictorA, radec= 5:19:49.721 -45:46:43.7801, tags=target, type=scan_const_el, duration=0.0


### PR DESCRIPTION
## Description 

This PR add three new constant-elevation scanning modes.

## Motivation

The intensity mapping experiments need more control on how constant-elevation scans are being done. These new features should provide that.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change
- [ ] Other

## Details

### `scan_constant_el`
Perform a constant-elevation scan given the RA extent of the scan around the target position `scan_width_radec` and the speed of the scan `scan_speed_radec`.

```yaml
instrument:
  integration_time: 2

noise_diode:
  antennas: all
  cycle_len: 20.
  on_frac: 0.015
  lead_time: 12.

durations:
  start_time: 2025-08-23 03:10:00

scan:
  scan_width_radec: 4.0     # width in RA/Dec coordinate system in degrees
  scan_speed_radec: 4.0     # arcmin/sec scanning speed in RA/Dec

observation_loop:
  - LST: 0:10-23:50
    target_list:
      - name=PictorA, radec= 5:19:49.721 -45:46:43.7801, tags=target, type=scan_const_el, duration=0.0
```

```
$ astrokat-observe.py --yaml astrokat/test/test_scans/scan-const-el-sim-test.yaml 
2025-11-10 11:26:38Z - Setting up telescope for observation
2025-11-10 11:26:38Z - Observation start up
2025-11-10 11:26:38Z - Running astrokat version - 0.1.dev928+new.constant.el.scans.073a2a5
2025-11-10 11:26:38Z - Skipping instrument checks - approved_schedule does not exist
2025-11-10 11:26:38Z - Found 1 target(s): 0 from 0 catalogue(s), 0 from default catalogue and 1 as target string(s)
2025-08-23 03:10:00Z - Observation targets are ['PictorA']
2025-08-23 03:10:00Z - Set noise diode period to multiple of correlator dump period: cycle length = 20.0 [sec]
2025-08-23 03:10:00Z - Request: Set noise diode pattern to activate at 1755918612.0 (includes 12.0 sec lead time)
2025-08-23 03:10:00Z - Antennas found in subarray, setting ND: m011,m022,m033,m044
2025-08-23 03:10:00Z - Repeat noise diode pattern every 20.0 sec, with 0.3 sec on and apply pattern to ['m011', 'm022', 'm033', 'm044']
2025-08-23 03:10:12Z - Report: Switch noise-diode pattern on at 1755918612.0
2025-08-23 03:10:12Z - Waiting for observation setup
2025-08-23 03:10:15Z - INIT
2025-08-23 03:10:15Z - Slewing to first target
2025-08-23 03:11:00Z - Slewed to PictorA at azel (127.5, 56.0) deg
2025-08-23 03:11:00Z - Tracked PictorA for 0 seconds
2025-08-23 03:11:33Z - Pre-positioning to scan start (Az, El): (124.02, 56.22) deg
2025-08-23 03:11:07Z - Slewed to PictorA at azel (124.0, 56.2) deg
2025-08-23 03:11:07Z - Tracked PictorA for 0 seconds
2025-08-23 03:11:40Z - Scan center (Az, El): (127.62, 56.24) deg
2025-08-23 03:11:40Z - Scan duration is 60.00 s and scan speed is 0.12 deg/s
2025-08-23 03:11:40Z - Azimuth scan extent [-3.6, 3.6]
2025-08-23 03:11:40Z - Scan target: PictorA, tags=azel, 127:37:26.6 56:14:27.2, no flux info
2025-08-23 03:11:15Z - Slewed to PictorA at azel (127.6, 56.2) deg
2025-08-23 03:12:15Z - Observation list completed - ending observation
2025-08-23 03:12:15Z - Observation loop statistics
2025-08-23 03:12:15Z - Single run through observation target list
2025-08-23 03:12:15Z - Total observation time 135.34 sec (2.26 min)
2025-08-23 03:12:15Z - Targets observed :
2025-08-23 03:12:15Z - PictorA observed for 0.0 sec
2025-08-23 03:12:15Z - Observation clean up
2025-08-23 03:12:15Z - Returning telescope to startup state
2025-08-23 03:12:15Z - Resetting all noise diodes to "off"
```

### `multi_scan_const_el`

This is a back-and-forth constant-elevation scan over a specific duration given by `obs_duration`.  The parameters `scan_width_radec` and `scan_speed_radec` have the same meaning as in `scan_constant_el`. The declination extent, and thus the scanning box, will be automatically determined. The target will be placed at the center of the box. This can be think of as an alternative to the current `reverse_scan`, where the scan duration can be controlled.

<img width="977" height="706" alt="Screenshot 2025-11-10 at 13 50 41" src="https://github.com/user-attachments/assets/c423f320-da93-4506-842a-713233a271a0" />

```yaml
instrument:
  integration_time: 2

noise_diode:
  antennas: all
  cycle_len: 20.
  on_frac: 0.015
  lead_time: 12.

durations:
  start_time: 2025-08-23 03:10:00

scan:
  obs_duration: 10.0        # 10 minutes total observation
  scan_width_radec: 4.0     # width in RA/Dec coordinate system in degrees
  scan_speed_radec: 4.0     # arcmin/sec scanning speed in RA/Dec

observation_loop:
  - LST: 0:10-23:50
    target_list:
      - name=PictorA, radec=5:19:49.721 -45:46:43.7801, tags=target, type=multi_scan_const_el, duration=0.0
```
```
$ astrokat-observe.py --yaml astrokat/test/test_scans/multi_scan_const_el.yaml 
2025-11-10 11:38:24Z - Setting up telescope for observation
2025-11-10 11:38:24Z - Observation start up
2025-11-10 11:38:24Z - Running astrokat version - 0.1.dev928+new.constant.el.scans.073a2a5
2025-11-10 11:38:24Z - Skipping instrument checks - approved_schedule does not exist
2025-11-10 11:38:24Z - Found 1 target(s): 0 from 0 catalogue(s), 0 from default catalogue and 1 as target string(s)
2025-08-23 03:10:00Z - Observation targets are ['PictorA']
2025-08-23 03:10:00Z - Set noise diode period to multiple of correlator dump period: cycle length = 20.0 [sec]
2025-08-23 03:10:00Z - Request: Set noise diode pattern to activate at 1755918612.0 (includes 12.0 sec lead time)
2025-08-23 03:10:00Z - Antennas found in subarray, setting ND: m011,m022,m033,m044
2025-08-23 03:10:00Z - Repeat noise diode pattern every 20.0 sec, with 0.3 sec on and apply pattern to ['m011', 'm022', 'm033', 'm044']
2025-08-23 03:10:12Z - Report: Switch noise-diode pattern on at 1755918612.0
2025-08-23 03:10:12Z - Waiting for observation setup
2025-08-23 03:10:15Z - INIT
2025-08-23 03:10:15Z - Slewing to first target
2025-08-23 03:11:00Z - Slewed to PictorA at azel (127.5, 56.0) deg
2025-08-23 03:11:00Z - Tracked PictorA for 0 seconds
2025-08-23 03:11:00Z - Individual scan line duration: 60.00 s
2025-08-23 03:11:00Z - Planning 10 scan lines over 10.0 minutes (requested: 10.0 min)
2025-08-23 03:16:34Z - Pre-positioning to first scan start (Az, El): (124.30, 57.07) deg
2025-08-23 03:11:07Z - Slewed to PictorA at azel (124.3, 57.1) deg
2025-08-23 03:11:07Z - Tracked PictorA for 0 seconds
2025-08-23 03:16:25Z - Target at obs middle (Az, El): (127.97, 57.05) deg
2025-08-23 03:16:25Z - Converted scan width: 7.35 deg in azimuth
2025-08-23 03:16:25Z - Converted scan speed: 0.12 deg/s in azimuth
2025-08-23 03:16:25Z - Scan line 1: West->East at (Az, El): (127.97, 57.05) deg
2025-08-23 03:16:25Z - Azimuth scan extent [-3.7, 3.7]
2025-08-23 03:16:25Z - Scan target: PictorA, tags=azel, 127:58:06.3 57:02:54.0, no flux info
2025-08-23 03:11:15Z - Slewed to PictorA at azel (128.0, 57.0) deg
2025-08-23 03:12:15Z - Scan line 2: East->West at (Az, El): (127.97, 57.05) deg
2025-08-23 03:12:15Z - Azimuth scan extent [3.7, -3.7]
2025-08-23 03:12:15Z - Scan target: PictorA, tags=azel, 127:58:06.3 57:02:54.0, no flux info
2025-08-23 03:12:15Z - Slewed to PictorA at azel (128.0, 57.0) deg
2025-08-23 03:13:15Z - Scan line 3: West->East at (Az, El): (127.97, 57.05) deg
2025-08-23 03:13:15Z - Azimuth scan extent [-3.7, 3.7]
2025-08-23 03:13:15Z - Scan target: PictorA, tags=azel, 127:58:06.3 57:02:54.0, no flux info
2025-08-23 03:13:15Z - Slewed to PictorA at azel (128.0, 57.0) deg
2025-08-23 03:14:15Z - Scan line 4: East->West at (Az, El): (127.97, 57.05) deg
2025-08-23 03:14:15Z - Azimuth scan extent [3.7, -3.7]
2025-08-23 03:14:15Z - Scan target: PictorA, tags=azel, 127:58:06.3 57:02:54.0, no flux info
2025-08-23 03:14:15Z - Slewed to PictorA at azel (128.0, 57.0) deg
2025-08-23 03:15:15Z - Scan line 5: West->East at (Az, El): (127.97, 57.05) deg
2025-08-23 03:15:15Z - Azimuth scan extent [-3.7, 3.7]
2025-08-23 03:15:15Z - Scan target: PictorA, tags=azel, 127:58:06.3 57:02:54.0, no flux info
2025-08-23 03:15:15Z - Slewed to PictorA at azel (128.0, 57.0) deg
2025-08-23 03:16:15Z - Scan line 6: East->West at (Az, El): (127.97, 57.05) deg
2025-08-23 03:16:15Z - Azimuth scan extent [3.7, -3.7]
2025-08-23 03:16:15Z - Scan target: PictorA, tags=azel, 127:58:06.3 57:02:54.0, no flux info
2025-08-23 03:16:15Z - Slewed to PictorA at azel (128.0, 57.0) deg
2025-08-23 03:17:15Z - Scan line 7: West->East at (Az, El): (127.97, 57.05) deg
2025-08-23 03:17:15Z - Azimuth scan extent [-3.7, 3.7]
2025-08-23 03:17:15Z - Scan target: PictorA, tags=azel, 127:58:06.3 57:02:54.0, no flux info
2025-08-23 03:17:15Z - Slewed to PictorA at azel (128.0, 57.0) deg
2025-08-23 03:18:15Z - Scan line 8: East->West at (Az, El): (127.97, 57.05) deg
2025-08-23 03:18:15Z - Azimuth scan extent [3.7, -3.7]
2025-08-23 03:18:15Z - Scan target: PictorA, tags=azel, 127:58:06.3 57:02:54.0, no flux info
2025-08-23 03:18:15Z - Slewed to PictorA at azel (128.0, 57.0) deg
2025-08-23 03:19:15Z - Scan line 9: West->East at (Az, El): (127.97, 57.05) deg
2025-08-23 03:19:15Z - Azimuth scan extent [-3.7, 3.7]
2025-08-23 03:19:15Z - Scan target: PictorA, tags=azel, 127:58:06.3 57:02:54.0, no flux info
2025-08-23 03:19:15Z - Slewed to PictorA at azel (128.0, 57.0) deg
2025-08-23 03:20:15Z - Scan line 10: East->West at (Az, El): (127.97, 57.05) deg
2025-08-23 03:20:15Z - Azimuth scan extent [3.7, -3.7]
2025-08-23 03:20:15Z - Scan target: PictorA, tags=azel, 127:58:06.3 57:02:54.0, no flux info
2025-08-23 03:20:15Z - Slewed to PictorA at azel (128.0, 57.0) deg
2025-08-23 03:21:15Z - Multi-scan completed - 10 scan lines executed
2025-08-23 03:21:15Z - Observation list completed - ending observation
2025-08-23 03:21:15Z - Observation loop statistics
2025-08-23 03:21:15Z - Single run through observation target list
2025-08-23 03:21:15Z - Total observation time 675.44 sec (11.26 min)
2025-08-23 03:21:15Z - Targets observed :
2025-08-23 03:21:15Z - PictorA observed for 0.0 sec
2025-08-23 03:21:15Z - Observation clean up
2025-08-23 03:21:15Z - Returning telescope to startup state
2025-08-23 03:21:15Z - Resetting all noise diodes to "off"
```

### `multi_scan_target_el`

Similar to `multi_scan_const_el` except that each scan will always go through the target at the middle of the scan. It requires `num_scan_lines` parameters, providing the number of the scan.

<img width="759" height="896" alt="Screenshot 2025-11-10 at 13 50 33" src="https://github.com/user-attachments/assets/d2530764-15e0-486a-beab-37b8dd949d8a" />

```yaml
instrument:
  integration_time: 2

noise_diode:
  antennas: all
  cycle_len: 20.
  on_frac: 0.015
  lead_time: 12.

durations:
  start_time: 2025-08-23 03:10:00

scan:
  scan_width_radec: 4.0     # 1 degree width in RA/Dec coordinate system
  scan_speed_radec: 4.0     # 2 arcmin/sec scanning speed in RA/Dec
  num_scan_lines: 10         # Number of scan lines through target

observation_loop:
  - LST: 0:10-23:50
    target_list:
      - name=PictorA, radec=5:19:49.721 -45:46:43.7801, tags=target, type=multi_scan_target_el, duration=0.0
```

```
$ astrokat-observe.py --yaml astrokat/test/test_scans/multi_scan_target_el.yaml 
2025-11-10 11:42:45Z - Setting up telescope for observation
2025-11-10 11:42:45Z - Observation start up
2025-11-10 11:42:45Z - Running astrokat version - 0.1.dev928+new.constant.el.scans.073a2a5
2025-11-10 11:42:45Z - Skipping instrument checks - approved_schedule does not exist
2025-11-10 11:42:45Z - Found 1 target(s): 0 from 0 catalogue(s), 0 from default catalogue and 1 as target string(s)
2025-08-23 03:10:00Z - Observation targets are ['PictorA']
2025-08-23 03:10:00Z - Set noise diode period to multiple of correlator dump period: cycle length = 20.0 [sec]
2025-08-23 03:10:00Z - Request: Set noise diode pattern to activate at 1755918612.0 (includes 12.0 sec lead time)
2025-08-23 03:10:00Z - Antennas found in subarray, setting ND: m011,m022,m033,m044
2025-08-23 03:10:00Z - Repeat noise diode pattern every 20.0 sec, with 0.3 sec on and apply pattern to ['m011', 'm022', 'm033', 'm044']
2025-08-23 03:10:12Z - Report: Switch noise-diode pattern on at 1755918612.0
2025-08-23 03:10:12Z - Waiting for observation setup
2025-08-23 03:10:15Z - INIT
2025-08-23 03:10:15Z - Slewing to first target
2025-08-23 03:11:00Z - Slewed to PictorA at azel (127.5, 56.0) deg
2025-08-23 03:11:00Z - Tracked PictorA for 0 seconds
2025-08-23 03:11:00Z - Planning 10 scan lines through target
2025-08-23 03:11:00Z - Individual scan line duration: 60.00 s
2025-08-23 03:11:33Z - Pre-positioning to first scan start (Az, El): (124.02, 56.22) deg
2025-08-23 03:11:07Z - Slewed to PictorA at azel (124.0, 56.2) deg
2025-08-23 03:11:07Z - Tracked PictorA for 0 seconds
2025-08-23 03:11:40Z - Scan line 1: West->East at (Az, El): (127.62, 56.24) deg
2025-08-23 03:11:40Z - Azimuth scan extent [-3.6, 3.6]
2025-08-23 03:11:40Z - Scan target: PictorA, tags=azel, 127:37:26.6 56:14:27.2, no flux info
2025-08-23 03:11:15Z - Slewed to PictorA at azel (127.6, 56.2) deg
2025-08-23 03:12:48Z - Scan line 2: East->West at (Az, El): (127.70, 56.43) deg
2025-08-23 03:12:48Z - Azimuth scan extent [3.6, -3.6]
2025-08-23 03:12:48Z - Scan target: PictorA, tags=azel, 127:42:09.7 56:25:59.9, no flux info
2025-08-23 03:12:19Z - Slewed to PictorA at azel (127.7, 56.4) deg
2025-08-23 03:13:52Z - Scan line 3: West->East at (Az, El): (127.78, 56.62) deg
2025-08-23 03:13:52Z - Azimuth scan extent [-3.6, 3.6]
2025-08-23 03:13:52Z - Scan target: PictorA, tags=azel, 127:46:44.4 56:36:54.9, no flux info
2025-08-23 03:13:23Z - Slewed to PictorA at azel (127.8, 56.6) deg
2025-08-23 03:14:56Z - Scan line 4: East->West at (Az, El): (127.86, 56.80) deg
2025-08-23 03:14:56Z - Azimuth scan extent [3.7, -3.7]
2025-08-23 03:14:56Z - Scan target: PictorA, tags=azel, 127:51:25.5 56:47:48.8, no flux info
2025-08-23 03:14:27Z - Slewed to PictorA at azel (127.9, 56.8) deg
2025-08-23 03:16:00Z - Scan line 5: West->East at (Az, El): (127.94, 56.98) deg
2025-08-23 03:16:00Z - Azimuth scan extent [-3.7, 3.7]
2025-08-23 03:16:00Z - Scan target: PictorA, tags=azel, 127:56:13.3 56:58:41.9, no flux info
2025-08-23 03:15:31Z - Slewed to PictorA at azel (127.9, 57.0) deg
2025-08-23 03:17:04Z - Scan line 6: East->West at (Az, El): (128.02, 57.16) deg
2025-08-23 03:17:04Z - Azimuth scan extent [3.7, -3.7]
2025-08-23 03:17:04Z - Scan target: PictorA, tags=azel, 128:01:08.1 57:09:34.3, no flux info
2025-08-23 03:16:35Z - Slewed to PictorA at azel (128.0, 57.2) deg
2025-08-23 03:18:08Z - Scan line 7: West->East at (Az, El): (128.10, 57.34) deg
2025-08-23 03:18:08Z - Azimuth scan extent [-3.7, 3.7]
2025-08-23 03:18:08Z - Scan target: PictorA, tags=azel, 128:06:09.7 57:20:26.0, no flux info
2025-08-23 03:17:39Z - Slewed to PictorA at azel (128.1, 57.3) deg
2025-08-23 03:19:12Z - Scan line 8: East->West at (Az, El): (128.19, 57.52) deg
2025-08-23 03:19:12Z - Azimuth scan extent [3.7, -3.7]
2025-08-23 03:19:12Z - Scan target: PictorA, tags=azel, 128:11:18.3 57:31:16.9, no flux info
2025-08-23 03:18:43Z - Slewed to PictorA at azel (128.2, 57.5) deg
2025-08-23 03:20:16Z - Scan line 9: West->East at (Az, El): (128.28, 57.70) deg
2025-08-23 03:20:16Z - Azimuth scan extent [-3.7, 3.7]
2025-08-23 03:20:16Z - Scan target: PictorA, tags=azel, 128:16:34.1 57:42:07.0, no flux info
2025-08-23 03:19:47Z - Slewed to PictorA at azel (128.3, 57.7) deg
2025-08-23 03:21:20Z - Scan line 10: East->West at (Az, El): (128.37, 57.88) deg
2025-08-23 03:21:20Z - Azimuth scan extent [3.8, -3.8]
2025-08-23 03:21:20Z - Scan target: PictorA, tags=azel, 128:21:57.2 57:52:56.3, no flux info
2025-08-23 03:20:51Z - Slewed to PictorA at azel (128.4, 57.9) deg
2025-08-23 03:21:51Z - Multi-scan target completed - 10 scan lines executed
2025-08-23 03:21:51Z - Observation list completed - ending observation
2025-08-23 03:21:51Z - Observation loop statistics
2025-08-23 03:21:51Z - Single run through observation target list
2025-08-23 03:21:51Z - Total observation time 711.41 sec (11.86 min)
2025-08-23 03:21:51Z - Targets observed :
2025-08-23 03:21:51Z - PictorA observed for 0.0 sec
2025-08-23 03:21:51Z - Observation clean up
2025-08-23 03:21:51Z - Returning telescope to startup state
2025-08-23 03:21:51Z - Resetting all noise diodes to "off"
```