### PR TITLE
SPP1-168: Set CBF target to middle (ra, dec) of each scan in OTF mapping [release]

### DIFF
--- a/astrokat/noisediode.py
+++ b/astrokat/noisediode.py
@@ -179,6 +179,7 @@ def nd_reset(kat,
              timestamp="now",
              switch=0):
     """Reset noise-source on or off.
+
     Parameters
     ----------
     kat : session kat container-like object

--- a/astrokat/observe_main.py
+++ b/astrokat/observe_main.py
@@ -98,6 +98,20 @@ def observe(session, ref_antenna, target_info, **kwargs):
         target.body._dec = dec_dms
 
     # simple way to get telescope to slew to target
+    #
+    # NOTE: This small bit of code has had a troubled history :-)
+    # - started off as a basic 0-second track
+    # - #92: Replaced with fancy slew function to accommodate FBFUSE
+    # - #93: Reverted back to 0-second track
+    # - #113: Used new "slew_only" functionality in session.track
+    # - #129: Stripped that out again since #114 was never released to site
+    #
+    # If you want to restore "slew_only" functionality with the new
+    # target dict approach, do the following:
+    #
+    #   session.track({"ants": target}, duration=0.0, announce=False)
+    #
+    # But this might not help the FBFUSE's cause...
     if "slewonly" in kwargs:
         return session.track(target, duration=0.0, announce=False)
 

--- a/astrokat/observe_main.py
+++ b/astrokat/observe_main.py
@@ -76,9 +76,8 @@ def observe(session, ref_antenna, target_info, **kwargs):
 
     Parameters
     ----------
-    session: `CaptureSession`
-    target_info:
-
+    session: `CaptureSession` object
+    target_info: dictionary with target observation info
     """
     target_visible = False
 

--- a/astrokat/scans.py
+++ b/astrokat/scans.py
@@ -111,11 +111,11 @@ def scan(session, target, nd_period=None, lead_time=None, **kwargs):
 
     """
     if isinstance(target, dict):
-        scan_target = target.get('ants')
-        radec_target = target.get('cbf')
+        ants_target = target.get('ants')
+        cbf_target = target.get('cbf')
     else:
-        scan_target = target
-        radec_target = target
+        ants_target = target
+        cbf_target = target
 
     # trigger noise diode if set
     trigger(session.kat, duration=nd_period, lead_time=lead_time)
@@ -124,9 +124,9 @@ def scan(session, target, nd_period=None, lead_time=None, **kwargs):
     except AttributeError:
         timestamp = time.time()
     user_logger.debug("DEBUG: Starting scan across target: {}".format(timestamp))
-    user_logger.info("Scan target: {}".format(scan_target))
+    user_logger.info("Scan target: {}".format(ants_target))
     # pass through the cbf, similar to session
-    user_logger.info("Scanning across radec target : {}".format(radec_target))
+    user_logger.info("Scanning across CBF target : {}".format(cbf_target))
     return session.scan(target, **kwargs)
 
 
@@ -340,10 +340,7 @@ def reversescan(session, target, nd_period=None, lead_time=None, **kwargs):
         user_logger.info("Azimuth scan extent [%.1f, %.1f]" %
                          (scanargs["start"][0], scanargs["end"][0]))
 
-        # Determine the cbf targets
-        # use scan_target to the astrometric (ra, dec)
-        # the ants to scan across the the delay tracking source
-        # the antenna we use is from the target list
+        # CBF target is (ra, dec) position of reference antenna in middle of next scan
         time_radec = time.time() + scan_duration / 2.0
         ra, dec = scan_target.radec(time_radec, antenna)
         cbf_target = katpoint.construct_radec_target(ra, dec)

--- a/astrokat/scans.py
+++ b/astrokat/scans.py
@@ -315,16 +315,6 @@ def reversescan(session, target, nd_period=None, lead_time=None, **kwargs):
     scan_start = np.degrees(az_min - (az_min + az_max) / 2.)
     scan_end = np.degrees(az_max - (az_min + az_max) / 2.)
 
-    # Determine the cbf targets
-    # use scan_target to the astrometric (ra, dec)
-    # the ants to scan across the the delay tracking source
-    # the antenna we use is from the target list
-    time_radec = (t_start + t_end) / 2
-    ra, dec = scan_target.radec(time_radec, antenna)
-    cbf_target = katpoint.construct_radec_target(ra, dec)
-    # Set target dictionary
-    target_dict = {'ants': scan_target, 'cbf': cbf_target}
-
     scanargs = {}
     if "projection" in kwargs:
         scanargs["projection"] = kwargs["projection"]
@@ -332,10 +322,10 @@ def reversescan(session, target, nd_period=None, lead_time=None, **kwargs):
     # take into account projection effects of the sky and convert to degrees per second
     # E.g., 5 arcmin/s should translate to 5/60/cos(el) deg/s
     scan_speed = (scan_speed / 60.0) / np.cos(el)
-    scanargs["duration"] = abs(scan_start - scan_end) / scan_speed  # Duration in seconds
+    scan_duration = scanargs["duration"] = abs(scan_start - scan_end) / scan_speed  # Duration in seconds
     user_logger.info(
         "Scan duration is %.2f and scan speed is %.2f deg/s",
-        scanargs["duration"], scan_speed
+        scan_duration, scan_speed
     )
     user_logger.info("Start Time: %s", t_start)
     user_logger.info("End Time: %s", t_end)
@@ -349,6 +339,17 @@ def reversescan(session, target, nd_period=None, lead_time=None, **kwargs):
             scanargs["end"] = scan_start, 0.0
         user_logger.info("Azimuth scan extent [%.1f, %.1f]" %
                          (scanargs["start"][0], scanargs["end"][0]))
+
+        # Determine the cbf targets
+        # use scan_target to the astrometric (ra, dec)
+        # the ants to scan across the the delay tracking source
+        # the antenna we use is from the target list
+        time_radec = time.time() + scan_duration / 2.0
+        ra, dec = scan_target.radec(time_radec, antenna)
+        cbf_target = katpoint.construct_radec_target(ra, dec)
+        # Set target dictionary
+        target_dict = {'ants': scan_target, 'cbf': cbf_target}
+
         target_visible = scan(session,
                               target_dict,
                               nd_period=nd_period,

--- a/astrokat/scans.py
+++ b/astrokat/scans.py
@@ -110,6 +110,13 @@ def scan(session, target, nd_period=None, lead_time=None, **kwargs):
         noisediode trigger lead time
 
     """
+    if isinstance(target, dict):
+        scan_target = target.get('ants')
+        radec_target = target.get('cbf')
+    else:
+        scan_target = target
+        radec_target = target
+
     # trigger noise diode if set
     trigger(session.kat, duration=nd_period, lead_time=lead_time)
     try:
@@ -117,7 +124,9 @@ def scan(session, target, nd_period=None, lead_time=None, **kwargs):
     except AttributeError:
         timestamp = time.time()
     user_logger.debug("DEBUG: Starting scan across target: {}".format(timestamp))
-    user_logger.info("Scan target: {}".format(target))
+    user_logger.info("Scan target: {}".format(scan_target))
+    # pass through the cbf, similar to session
+    user_logger.info("Scanning across radec target : {}".format(radec_target))
     return session.scan(target, **kwargs)
 
 
@@ -303,9 +312,18 @@ def reversescan(session, target, nd_period=None, lead_time=None, **kwargs):
     # restore datetime before continuing
     scan_target.antenna = antenna
     scan_target.antenna.observer.date = obs_start_ts
-
     scan_start = np.degrees(az_min - (az_min + az_max) / 2.)
     scan_end = np.degrees(az_max - (az_min + az_max) / 2.)
+
+    # Determine the cbf targets
+    # use scan_target to the astrometric (ra, dec)
+    # the ants to scan across the the delay tracking source
+    # the antenna we use is from the target list
+    time_radec = (t_start + t_end) / 2
+    ra, dec = scan_target.radec(time_radec, antenna)
+    cbf_target = katpoint.construct_radec_target(ra, dec)
+    # Set target dictionary
+    target_dict = {'ants': scan_target, 'cbf': cbf_target}
 
     scanargs = {}
     if "projection" in kwargs:
@@ -332,7 +350,7 @@ def reversescan(session, target, nd_period=None, lead_time=None, **kwargs):
         user_logger.info("Azimuth scan extent [%.1f, %.1f]" %
                          (scanargs["start"][0], scanargs["end"][0]))
         target_visible = scan(session,
-                              scan_target,
+                              target_dict,
                               nd_period=nd_period,
                               lead_time=lead_time,
                               **scanargs)

--- a/astrokat/scans.py
+++ b/astrokat/scans.py
@@ -322,9 +322,9 @@ def reversescan(session, target, nd_period=None, lead_time=None, **kwargs):
     # take into account projection effects of the sky and convert to degrees per second
     # E.g., 5 arcmin/s should translate to 5/60/cos(el) deg/s
     scan_speed = (scan_speed / 60.0) / np.cos(el)
-    scan_duration = scanargs["duration"] = abs(scan_start - scan_end) / scan_speed  # Duration in seconds
+    scan_duration = scanargs["duration"] = abs(scan_start - scan_end) / scan_speed
     user_logger.info(
-        "Scan duration is %.2f and scan speed is %.2f deg/s",
+        "Scan duration is %.2f seconds and scan speed is %.2f degrees per second",
         scan_duration, scan_speed
     )
     user_logger.info("Start Time: %s", t_start)

--- a/astrokat/simulate.py
+++ b/astrokat/simulate.py
@@ -291,9 +291,15 @@ class SimSession(object):
         announce:
 
         """
-        slew_time, az, el = self._fake_slew_(target)
+        if isinstance(target, dict):
+            scan_target = target.get('ants')
+        else:
+            scan_target = target
+
+        slew_time, az, el = self._fake_slew_(scan_target)
         time.sleep(slew_time)
-        user_logger.info("Slewed to %s at azel (%.1f, %.1f) deg", target.name, az, el)
+        user_logger.info("Slewed to %s at azel (%.1f, %.1f) deg",
+                         scan_target.name, az, el)
         time.sleep(duration)
         return True
 
@@ -362,21 +368,29 @@ class SimSession(object):
             The elevation co-ordinate of the target in degrees.
 
         """
-        az, el = target.azel(simobserver.date)
+        if isinstance(target, dict):
+            scan_target = target.get('ants')
+        else:
+            scan_target = target
+        az, el = scan_target.azel(simobserver.date)
         az = katpoint.rad2deg(az)
         el = katpoint.rad2deg(el)
         return az, el
 
     def _fake_slew_(self, target):
+        if isinstance(target, dict):
+            scan_target = target.get('ants')
+        else:
+            scan_target = target
         slew_time = 0
-        az, el = self._target_azel(target)
+        az, el = self._target_azel(scan_target)
         if target != self.katpt_current:
             if self.katpt_current is None:
                 slew_time = _DEFAULT_SLEW_TIME_SEC
             else:
-                user_logger.debug("Slewing to {}".format(target.name))
+                user_logger.debug("Slewing to {}".format(scan_target.name))
                 slew_time = self._slew_time(az, el)
-            self.katpt_current = target
+            self.katpt_current = scan_target
         return slew_time, az, el
 
     def _slew_time(self, new_az, new_el):
@@ -395,6 +409,7 @@ class SimSession(object):
             The number of seconds it takes to slew.
 
         """
+
         current_az, current_el = self._target_azel(self.katpt_current)
 
         az_dist = numpy.abs(new_az - current_az)

--- a/astrokat/simulate.py
+++ b/astrokat/simulate.py
@@ -225,7 +225,9 @@ class SimSession(object):
             The target to be tracked
         duration: int
             Duration of track
-
+        announce : bool, optional
+            True if start of action should be announced, with details of
+            settings
         """
         self.track_ = True
         slew_time, az, el = self._fake_slew_(target)

--- a/astrokat/simulate.py
+++ b/astrokat/simulate.py
@@ -294,14 +294,14 @@ class SimSession(object):
 
         """
         if isinstance(target, dict):
-            scan_target = target.get('ants')
+            ants_target = target.get('ants')
         else:
-            scan_target = target
+            ants_target = target
 
-        slew_time, az, el = self._fake_slew_(scan_target)
+        slew_time, az, el = self._fake_slew_(ants_target)
         time.sleep(slew_time)
         user_logger.info("Slewed to %s at azel (%.1f, %.1f) deg",
-                         scan_target.name, az, el)
+                         ants_target.name, az, el)
         time.sleep(duration)
         return True
 
@@ -371,28 +371,28 @@ class SimSession(object):
 
         """
         if isinstance(target, dict):
-            scan_target = target.get('ants')
+            ants_target = target.get('ants')
         else:
-            scan_target = target
-        az, el = scan_target.azel(simobserver.date)
+            ants_target = target
+        az, el = ants_target.azel(simobserver.date)
         az = katpoint.rad2deg(az)
         el = katpoint.rad2deg(el)
         return az, el
 
     def _fake_slew_(self, target):
         if isinstance(target, dict):
-            scan_target = target.get('ants')
+            ants_target = target.get('ants')
         else:
-            scan_target = target
+            ants_target = target
         slew_time = 0
-        az, el = self._target_azel(scan_target)
+        az, el = self._target_azel(ants_target)
         if target != self.katpt_current:
             if self.katpt_current is None:
                 slew_time = _DEFAULT_SLEW_TIME_SEC
             else:
-                user_logger.debug("Slewing to {}".format(scan_target.name))
+                user_logger.debug("Slewing to {}".format(ants_target.name))
                 slew_time = self._slew_time(az, el)
-            self.katpt_current = scan_target
+            self.katpt_current = ants_target
         return slew_time, az, el
 
     def _slew_time(self, new_az, new_el):

--- a/astrokat/test/test_scans.py
+++ b/astrokat/test/test_scans.py
@@ -109,7 +109,7 @@ class TestAstrokatYAML(unittest.TestCase):
         self.assertIn("Scan completed - 48 scan lines", result)
         # Check the an radec target is fixed and been scanned across
         self.assertEqual(result.count('Scan target: scan_azel_with_nd_trigger,'), 48)
-        self.assertEqual(result.count('Scanning across radec target : '), 48)
+        self.assertEqual(result.count('Scanning across CBF target : '), 48)
 
     def assert_started_target_track(self, target_string, duration, result):
         simulate_message = "Slewed to {} at azel".format(target_string)

--- a/astrokat/test/test_scans.py
+++ b/astrokat/test/test_scans.py
@@ -107,7 +107,9 @@ class TestAstrokatYAML(unittest.TestCase):
         self.assertIn("scan speed is 0.14 deg/s", result)
         self.assertIn("Azimuth scan extent [-8.3, 8.3]", result)
         self.assertIn("Scan completed - 48 scan lines", result)
+        # Check the an radec target is fixed and been scanned across
         self.assertEqual(result.count('Scan target: scan_azel_with_nd_trigger,'), 48)
+        self.assertEqual(result.count('Scanning across radec target : '), 48)
 
     def assert_started_target_track(self, target_string, duration, result):
         simulate_message = "Slewed to {} at azel".format(target_string)

--- a/astrokat/test/test_scans.py
+++ b/astrokat/test/test_scans.py
@@ -104,7 +104,7 @@ class TestAstrokatYAML(unittest.TestCase):
         # Check that calibration tracks can be done
         self.assertIn("PictorA_r0.5", result)
         # Check scan details
-        self.assertIn("scan speed is 0.14 deg/s", result)
+        self.assertIn("scan speed is 0.14 degrees per second", result)
         self.assertIn("Azimuth scan extent [-8.3, 8.3]", result)
         self.assertIn("Scan completed - 48 scan lines", result)
         # Check the an radec target is fixed and been scanned across


### PR DESCRIPTION
This releases #129 to site, while also bringing the `release/karoocamv30` and `master` branches into sync with each other. I've cherry-picked the 7 commits of #129 and added 2 more to make the branches identical.

This has been validated on-site:

- [Site (2025-10-01, 2025-12-08)](https://skaafrica.atlassian.net/browse/NSO-27)
- [Site (2026-04-22)](https://skaafrica.atlassian.net/browse/NSO-39)
