### PR TITLE
Update SimSession AQF Tests Behavior to Match Katcorelib  MKAT Session 

### DIFF
--- a/astrokat/simulate.py
+++ b/astrokat/simulate.py
@@ -337,7 +337,6 @@ class SimSession(object):
             len(offsets),
             track_duration,
         )
-        #self.track(target, duration=0, announce=False)
         for offset in offsets:
             user_logger.info("initiating track on offset of (%g, %g) degrees", *offset)
             self.track(target, track_duration, announce=False)

--- a/astrokat/simulate.py
+++ b/astrokat/simulate.py
@@ -341,10 +341,6 @@ class SimSession(object):
             user_logger.info("initiating track on offset of (%g, %g) degrees", *offset)
             self.track(target, track_duration, announce=False)
         user_logger.info("Waiting for fitted beams to materialise in cal pipeline")
-        user_logger.info(
-            "reference time = %.1f, weather = %.1f deg C | %.1f hPa | %.1f %%",
-            # make these up...
-        )
         user_logger.info("Calculating and storing pointing offsets")
         return True
 

--- a/astrokat/simulate.py
+++ b/astrokat/simulate.py
@@ -323,7 +323,7 @@ class SimSession(object):
         num_pointings: int
             Number of offset pointings
         """
-        scan = numpy.linspace(-extent, extent, (num_pointings -1) // 2)
+        scan = numpy.linspace(-extent, extent, (num_pointings - 1) // 2)
         offsets_along_x = numpy.c_[scan, numpy.zeros_like(scan)]
         offsets_along_y = numpy.c_[numpy.zeros_like(scan), scan]
         offsets = numpy.r_[offsets_along_y, offsets_along_x, [(0.0, 0.0)]]

--- a/astrokat/simulate.py
+++ b/astrokat/simulate.py
@@ -50,7 +50,7 @@ def setobserver(update):
 
     """
     global simobserver
-    simobserver = update.copy()
+    simobserver = update
 
 
 def sim_time(record, datefmt=None):
@@ -375,9 +375,7 @@ class SimSession(object):
             ants_target = target.get('ants')
         else:
             ants_target = target
-        observer_date = target.antenna.observer.date
         az, el = ants_target.azel(simobserver.date)
-        target.antenna.observer.date = observer_date
         az = katpoint.rad2deg(az)
         el = katpoint.rad2deg(el)
         return az, el

--- a/astrokat/simulate.py
+++ b/astrokat/simulate.py
@@ -50,7 +50,7 @@ def setobserver(update):
 
     """
     global simobserver
-    simobserver = update
+    simobserver = update.copy()
 
 
 def sim_time(record, datefmt=None):
@@ -323,26 +323,27 @@ class SimSession(object):
         num_pointings: int
             Number of offset pointings
         """
-        scan = numpy.linspace(-extent, extent, num_pointings // 2)
+        scan = numpy.linspace(-extent, extent, (num_pointings -1) // 2)
         offsets_along_x = numpy.c_[scan, numpy.zeros_like(scan)]
         offsets_along_y = numpy.c_[numpy.zeros_like(scan), scan]
-        offsets = numpy.r_[offsets_along_y, offsets_along_x]
+        offsets = numpy.r_[offsets_along_y, offsets_along_x, [(0.0, 0.0)]]
         offset_end_times = numpy.zeros(len(offsets))
         middle_time = 0.0
         weather = {}
+        track_duration = duration / num_pointings
 
         user_logger.info(
             "Initiating interferometric pointing scan on target "
             "'%s' (%d pointings of %g seconds each)",
             target.name,
             len(offsets),
-            duration,
+            track_duration,
         )
         self.track(target, duration=0, announce=False)
         # Point to the requested offsets and collect extra data at middle time
         for n, offset in enumerate(offsets):
             user_logger.info("initiating track on offset of (%g, %g) degrees", *offset)
-            self.track(target, duration, announce=False)
+            self.track(target, track_duration, announce=False)
             offset_end_times[n] = time.time()
             if n == len(offsets) // 2 - 1:
                 middle_time = offset_end_times[n]
@@ -374,7 +375,9 @@ class SimSession(object):
             ants_target = target.get('ants')
         else:
             ants_target = target
+        observer_date = target.antenna.observer.date
         az, el = ants_target.azel(simobserver.date)
+        target.antenna.observer.date = observer_date
         az = katpoint.rad2deg(az)
         el = katpoint.rad2deg(el)
         return az, el

--- a/astrokat/simulate.py
+++ b/astrokat/simulate.py
@@ -337,7 +337,7 @@ class SimSession(object):
             len(offsets),
             track_duration,
         )
-        self.track(target, duration=0, announce=False)
+        #self.track(target, duration=0, announce=False)
         for offset in offsets:
             user_logger.info("initiating track on offset of (%g, %g) degrees", *offset)
             self.track(target, track_duration, announce=False)

--- a/astrokat/simulate.py
+++ b/astrokat/simulate.py
@@ -327,8 +327,6 @@ class SimSession(object):
         offsets_along_x = numpy.c_[scan, numpy.zeros_like(scan)]
         offsets_along_y = numpy.c_[numpy.zeros_like(scan), scan]
         offsets = numpy.r_[offsets_along_y, offsets_along_x, [(0.0, 0.0)]]
-        offset_end_times = numpy.zeros(len(offsets))
-        middle_time = 0.0
         weather = {}
         track_duration = duration / num_pointings
 
@@ -340,19 +338,15 @@ class SimSession(object):
             track_duration,
         )
         self.track(target, duration=0, announce=False)
-        # Point to the requested offsets and collect extra data at middle time
-        for n, offset in enumerate(offsets):
+        for offset in offsets:
             user_logger.info("initiating track on offset of (%g, %g) degrees", *offset)
             self.track(target, track_duration, announce=False)
-            offset_end_times[n] = time.time()
-            if n == len(offsets) // 2 - 1:
-                middle_time = offset_end_times[n]
-                user_logger.info(
-                    "reference time = %.1f, weather = %r", middle_time, weather)
-        user_logger.info("returning to target to complete the scan")
-        self.track(target, duration=0, announce=False)
-        user_logger.info("Waiting for gains to materialise in cal pipeline")
-        user_logger.info("Retrieving gains, fitting beams, storing offsets")
+        user_logger.info("Waiting for fitted beams to materialise in cal pipeline")
+        user_logger.info(
+            "reference time = %.1f, weather = %.1f deg C | %.1f hPa | %.1f %%",
+            # make these up...
+        )
+        user_logger.info("Calculating and storing pointing offsets")
         return True
 
     def _target_azel(self, target):

--- a/astrokat/test/test_scans.py
+++ b/astrokat/test/test_scans.py
@@ -35,7 +35,7 @@ class TestAstrokatYAML(unittest.TestCase):
         self.assertIn("Drift_scan observation for 180.0 sec", result)
 
         # use running session to determine suitable target values
-        if os.getenv("SESSION_NAME") == "mkat_session":
+        if os.getenv("SESSION_TYPE") == "mkat_session":
             target_string = "Az: -159:01:46.8 El: 52:05:00.6"
         else:
             target_string = "Az: -158:55:32.5 El: 52:01:18.0"

--- a/astrokat/test/test_scans.py
+++ b/astrokat/test/test_scans.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+import os
 import unittest
 
 import katpoint
@@ -32,7 +33,12 @@ class TestAstrokatYAML(unittest.TestCase):
         result = LoggedTelescope.user_logger_stream.getvalue()
         self.assertIn("Initialising Drift_scan target 1934-638 for 180.0 sec", result)
         self.assertIn("Drift_scan observation for 180.0 sec", result)
-        target_string = "Az: -159:01:46.8 El: 52:05:00.6"
+        # use running session to determine suitable target values
+
+        if os.getenv("SESSION_NAME") == "mkat_session":
+            target_string = "Az: -159:01:46.8 El: 52:05:00.6"
+        else:
+            target_string = "Az: -158:55:32.5 El: 52:01:18.0"
         self.assert_started_target_track(target_string, 180.0, result)
         self.assert_completed_target_track(target_string, 180.0, result)
 

--- a/astrokat/test/test_scans.py
+++ b/astrokat/test/test_scans.py
@@ -33,12 +33,13 @@ class TestAstrokatYAML(unittest.TestCase):
         result = LoggedTelescope.user_logger_stream.getvalue()
         self.assertIn("Initialising Drift_scan target 1934-638 for 180.0 sec", result)
         self.assertIn("Drift_scan observation for 180.0 sec", result)
-        # use running session to determine suitable target values
 
+        # use running session to determine suitable target values
         if os.getenv("SESSION_NAME") == "mkat_session":
             target_string = "Az: -159:01:46.8 El: 52:05:00.6"
         else:
             target_string = "Az: -158:55:32.5 El: 52:01:18.0"
+
         self.assert_started_target_track(target_string, 180.0, result)
         self.assert_completed_target_track(target_string, 180.0, result)
 

--- a/astrokat/test/test_scans.py
+++ b/astrokat/test/test_scans.py
@@ -32,7 +32,7 @@ class TestAstrokatYAML(unittest.TestCase):
         result = LoggedTelescope.user_logger_stream.getvalue()
         self.assertIn("Initialising Drift_scan target 1934-638 for 180.0 sec", result)
         self.assertIn("Drift_scan observation for 180.0 sec", result)
-        target_string = "Az: -158:55:32.5 El: 52:01:18.0"
+        target_string = "Az: -159:01:46.8 El: 52:05:00.6"
         self.assert_started_target_track(target_string, 180.0, result)
         self.assert_completed_target_track(target_string, 180.0, result)
 
@@ -59,7 +59,7 @@ class TestAstrokatYAML(unittest.TestCase):
         result = LoggedTelescope.user_logger_stream.getvalue()
         self.assertIn("Initialising Reference_pointing_scan pointingcal "
                       "1934-638 for 144.0 sec", result)
-        self.assertIn("1934-638 observed for 144.0 sec", result)
+        self.assertIn("1934-638 observed for 288.0 sec", result)
         self.assertIn("Adjust pointing selected", result)
 
     def test_get_scan_area_extents_for_setting_target(self):


### PR DESCRIPTION
This change updates how SimSession handles duration for reference pointing to match the katcorelib mkat session behavior.  

**Test: test_scans.py:TestAstrokatYAML.test_drift_scan_basic_sim**
- At the end of the observation the test looks for  `"Initiating 180-second track on target 'Az: -158:55:32.5 El: 52:01:18.0'"` but logs have `"initiating 180-second track on target 'Az: -159:01:46.8 El: 52:05:00.6'"`.
- The unittest simulator adds sleep time when updating observers time. The discrepancy in timing arises from how the simulator and Session dry run handle observer time. 

AQF pipeline progress output:

```
DRY-RUN: 2018-07-23 00:10:39.148Z INFO     Initialising Drift_scan target 1934-638 for 180.0 sec
DRY-RUN: 2018-07-23 00:10:39.148Z INFO     New compound scan: 'drift_scan'
DRY-RUN: 2018-07-23 00:10:39.148Z INFO     obs_start_ts 2018/7/23 00:10:00, transit_time:2018/7/23 00:11:30 az: 200:58:13.2 el: 52:05:00.6
DRY-RUN: 2018-07-23 00:10:39.148Z INFO     Drift_scan observation for 180.0 sec
DRY-RUN: 2018-07-23 00:10:39.148Z INFO     Initiating 180-second track on target 'Az: -159:01:46.8 El: 52:05:00.6' 
```

Unittest progress output:

```
2018-07-23 00:10:48Z - Initialising Drift_scan target 1934-638 for 180.0 sec
2018-07-23 00:12:18Z - obs_start_ts 2018/7/23 00:10:48, transit_time:2018/7/23 00:12:18 az: 201:04:27.5 el: 52:01:18.0 ref_ant:ref: 0-m dish at lat -30:42:39.8, long 21:26:38.0, alt 1086.6 m
2018-07-23 00:10:48Z - Drift_scan observation for 180.0 sec
2018-07-23 00:10:51Z - Slewed to Az: -158:55:32.5 El: 52:01:18.0 at azel (-158.9, 52.0) deg
```

- The Session dry run uses a fixed observer time of 00:10:00, however the simulator specifically adds a 48-second lead. 3 seconds during capture-init and 45 seconds for the target slew, this creates the time offset.


**Test: test_scans.py:TestAstrokatYAML.test_reference_pointing_scan_basic_sim**
- At the end of the observation the test looks for `'1934-638 observed for 144.0 sec'` in the logs but the logs have `'1934-638 observed for 288.0 sec'`  that's because the observation runs for 288 seconds instead of 144 seconds.
- SimSession treats the duration parameter as the time allocated for each track offset, the AQF interprets it as the total duration for the entire reference pointing scan. This mismatch causes the script to cycle through observations incorrectly.

More details about the SimSession and Mkat Session discrepancies are further explained [here](https://skaafrica.atlassian.net/browse/MT-7082)

